### PR TITLE
Persist structured findings for MCP and trend analysis

### DIFF
--- a/noxaudit/runner.py
+++ b/noxaudit/runner.py
@@ -12,7 +12,7 @@ from noxaudit.decisions import filter_findings, format_decision_context, load_de
 from noxaudit.focus import FOCUS_AREAS
 from noxaudit.focus.base import build_combined_prompt, gather_files_combined
 from noxaudit.issues import create_issues_for_findings
-from noxaudit.mcp.state import save_latest_findings
+from noxaudit.mcp.state import append_findings_history, save_latest_findings
 from noxaudit.models import AuditResult, FileContent
 from noxaudit.notifications.telegram import send_telegram
 from noxaudit.pricing import MODEL_PRICING
@@ -390,6 +390,14 @@ def _retrieve_repo(config, batch_info, focus_label, default_focus, output_format
         focus=focus_label,
         timestamp=audit_result.timestamp,
         resolved_count=resolved_count,
+        provider=pname,
+    )
+    append_findings_history(
+        findings=new_findings,
+        repo=repo_name,
+        focus=focus_label,
+        timestamp=audit_result.timestamp,
+        provider=pname,
     )
 
     # Generate and save report
@@ -519,6 +527,14 @@ def _run_repo_sync(config, repo, focus_names, provider_name, dry_run, output_for
         focus=label,
         timestamp=result.timestamp,
         resolved_count=resolved_count,
+        provider=pname,
+    )
+    append_findings_history(
+        findings=new_findings,
+        repo=repo.name,
+        focus=label,
+        timestamp=result.timestamp,
+        provider=pname,
     )
 
     report = generate_report(result)


### PR DESCRIPTION
Closes atriumn/noxaudit#12

## Summary

The runner currently only persists findings as markdown reports. Both the MCP server (#7) and trend analysis (#5) need structured, queryable findings data. Add a `latest-findings.json` and `findings-history.jsonl` output to the runner pipeline.
Written after each audit run, overwriting the previous:
```json
{
  "timestamp": "2025-02-15T06:00:00",
  "repo": "my-app",
  "focus": "security",
  "provider": "anthropic",
  "findings": [
    {
      "id": "abc123",
      "severity": "high",
      "file

## Changes

- feat: persist structured findings to latest-findings.json and findings-history.jsonl

` 3 files changed, 117 insertions(+), 3 deletions(-)`

## Verification

- Tests: passed (verified before LOOP_COMPLETE)
- Lint: clean
- Commits: 1 on `feat/persist-structured-findings-for-mcp-and-12`

---
Automated PR by Ralph | **Model:** claude-sonnet-4-6 | **Duration:** 4m