### PR TITLE
benchmark: build benchmark runner script (+1 more)

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,2 @@
+results/
+!results/.gitkeep

--- a/benchmark/CORPUS.md
+++ b/benchmark/CORPUS.md
@@ -1,0 +1,101 @@
+# Benchmark Corpus
+
+Five repos selected for benchmarking noxaudit across providers, models, and focus areas.
+Each repo is pinned at a specific commit SHA for reproducibility.
+
+## Corpus
+
+| Repo | Language | Size | Commit SHA | Role |
+|------|----------|------|------------|------|
+| `atriumn/noxaudit` | Python | ~526 KB | `1503cbf22b08bbe7e64962221c7075474ed33f57` | Medium Python — our own product (dogfood) |
+| `atriumn/tokencost-dev` | TypeScript | ~3.9 MB | `7ee1423562cdc6dbecfd4959da789fc11da4a3b1` | Medium TS — MCP server, real-world complexity |
+| `atriumn/cryyer` | TypeScript | ~1 MB | `4f7ec8270bb9957e4276c063ca421a560daafd67` | Small TS — LLM-powered, Atriumn product |
+| `tiangolo/fastapi` | Python | Large (400+ files) | `ca5f60ee72f35fb2134d8b5d26bbb75965bcff66` | Large Python — stress-test context windows |
+| `theskumar/python-dotenv` | Python | Small (~10 files) | `da0c82054f1ec1e03d57356d49b0b9ad09eb4209` | Small Python — hallucination canary |
+
+## Rationale
+
+### atriumn/noxaudit
+Dogfooding: we run noxaudit against itself. Medium-sized Python repo (~526 KB) with a real
+security surface (API keys, provider auth, config loading). Known codebase gives us a ground
+truth to evaluate finding quality. Any model that misses obvious issues in our own code is
+disqualified for production use.
+
+### atriumn/tokencost-dev
+Medium TypeScript MCP server (~3.9 MB). Represents the TypeScript ecosystem and an MCP-pattern
+codebase. Large enough to stress model context handling, small enough to stay under most
+provider limits without pre-pass.
+
+### atriumn/cryyer
+Small TypeScript LLM-powered product (~1 MB). Tests how models handle a modern TS codebase
+with AI integrations — prompt injection, API key handling, output parsing. Provides a
+TypeScript counterpart to python-dotenv for cross-language comparison at small scale.
+
+### tiangolo/fastapi
+The de facto standard Python web framework — 400+ files, battle-tested, real security
+surface (auth middleware, dependency injection, input validation, OpenAPI generation).
+Serves two purposes:
+1. **Context stress test**: forces models to handle large repos gracefully
+2. **Security surface**: auth flows, header parsing, and middleware offer genuine
+   findings without being a deliberately broken codebase
+
+### theskumar/python-dotenv
+Deliberately simple (~10 files), well-maintained, no known security issues.
+Acts as a **hallucination canary**: models that find many high-severity issues in
+python-dotenv are likely hallucinating. Expected finding count: 0–2 low-severity
+observations at most. Models producing many findings here score poorly on precision.
+
+## Coverage Matrix
+
+| Dimension | Values |
+|-----------|--------|
+| Languages | Python, TypeScript |
+| Sizes | Small (python-dotenv, cryyer), Medium (noxaudit, tokencost-dev), Large (fastapi) |
+| Quality | Clean/well-maintained (python-dotenv, fastapi), Active product (noxaudit, cryyer, tokencost-dev) |
+| Ownership | Atriumn (noxaudit, tokencost-dev, cryyer), Open source (fastapi, python-dotenv) |
+
+## Setup
+
+Clone each repo and check out the pinned commit before running benchmarks:
+
+```bash
+# Clone to a local directory (adjust paths as needed)
+mkdir -p ~/benchmark-repos
+
+git clone https://github.com/atriumn/noxaudit ~/benchmark-repos/noxaudit
+git -C ~/benchmark-repos/noxaudit checkout 1503cbf22b08bbe7e64962221c7075474ed33f57
+
+git clone https://github.com/atriumn/tokencost-dev ~/benchmark-repos/tokencost-dev
+git -C ~/benchmark-repos/tokencost-dev checkout 7ee1423562cdc6dbecfd4959da789fc11da4a3b1
+
+git clone https://github.com/atriumn/cryyer ~/benchmark-repos/cryyer
+git -C ~/benchmark-repos/cryyer checkout 4f7ec8270bb9957e4276c063ca421a560daafd67
+
+git clone https://github.com/tiangolo/fastapi ~/benchmark-repos/fastapi
+git -C ~/benchmark-repos/fastapi checkout ca5f60ee72f35fb2134d8b5d26bbb75965bcff66
+
+git clone https://github.com/theskumar/python-dotenv ~/benchmark-repos/python-dotenv
+git -C ~/benchmark-repos/python-dotenv checkout da0c82054f1ec1e03d57356d49b0b9ad09eb4209
+```
+
+Then update the `path:` entries in `benchmark/corpus.yml` to match your local paths,
+and run:
+
+```bash
+python scripts/benchmark.py matrix benchmark/corpus.yml
+```
+
+## Updating the Corpus
+
+To re-pin the corpus to newer commits:
+
+```bash
+# For each repo, get the latest commit SHA:
+git -C ~/benchmark-repos/fastapi pull && git -C ~/benchmark-repos/fastapi rev-parse HEAD
+
+# Update the SHA in this file and in benchmark/corpus.yml
+```
+
+All benchmark results in `benchmark/results/` are keyed to these commit SHAs via the
+`meta.repo_commit` field, making it safe to re-run after updates without confusing old
+and new results.

--- a/benchmark/corpus.yml
+++ b/benchmark/corpus.yml
@@ -1,0 +1,74 @@
+# Noxaudit Benchmark Corpus
+#
+# Machine-readable matrix config for scripts/benchmark.py.
+# Run with: python scripts/benchmark.py matrix benchmark/corpus.yml
+#
+# Before running:
+#   1. Clone the corpus repos (see benchmark/CORPUS.md for commands)
+#   2. Update the `path:` entries below to match your local clone locations
+
+matrix:
+  # --- Provider × model combinations to test ---
+  providers:
+    - name: gemini
+      models:
+        - gemini-2.0-flash
+
+    - name: anthropic
+      models:
+        - claude-haiku-4-5-20251001
+        - claude-sonnet-4-5-20250929
+
+  # --- Focus tiers ---
+  # "security" for targeted security-only runs; "all" for full 7-area audits
+  focus:
+    - security
+    - all
+
+  # --- Number of runs per combination (for variance measurement) ---
+  runs: 3
+
+  # --- Corpus repos (pinned commit SHAs) ---
+  repos:
+    - name: noxaudit
+      path: ~/benchmark-repos/noxaudit  # update to your local path
+      commit: 1503cbf22b08bbe7e64962221c7075474ed33f57
+      exclude:
+        - "*.lock"
+        - ".venv/**"
+
+    - name: tokencost-dev
+      path: ~/benchmark-repos/tokencost-dev  # update to your local path
+      commit: 7ee1423562cdc6dbecfd4959da789fc11da4a3b1
+      exclude:
+        - "node_modules/**"
+        - "dist/**"
+        - "*.lock"
+
+    - name: cryyer
+      path: ~/benchmark-repos/cryyer  # update to your local path
+      commit: 4f7ec8270bb9957e4276c063ca421a560daafd67
+      exclude:
+        - "node_modules/**"
+        - "dist/**"
+        - "*.lock"
+
+    - name: fastapi
+      path: ~/benchmark-repos/fastapi  # update to your local path
+      commit: ca5f60ee72f35fb2134d8b5d26bbb75965bcff66
+      exclude:
+        - "*.lock"
+        - "docs/**"
+
+    - name: python-dotenv
+      path: ~/benchmark-repos/python-dotenv  # update to your local path
+      commit: da0c82054f1ec1e03d57356d49b0b9ad09eb4209
+      exclude: []
+
+  # --- Output ---
+  output_dir: benchmark/results
+
+  # --- Rate limiting ---
+  rate_limit:
+    sleep_between_runs: 5   # seconds between successful runs
+    backoff_on_error: 30    # seconds to wait after a failed run

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Benchmark runner for noxaudit.
+
+Runs noxaudit across a matrix of provider × model × repo × focus combinations
+and writes structured JSON results to benchmark/results/.
+
+Usage:
+    # Run full matrix from corpus config:
+    python scripts/benchmark.py matrix benchmark/corpus.yml
+
+    # Run a single combination:
+    python scripts/benchmark.py single \\
+        --repo noxaudit --repo-path /path/to/noxaudit \\
+        --provider gemini --model gemini-2.0-flash \\
+        --focus security --run 1
+
+    # Resume a partial run (automatically skips completed combos):
+    python scripts/benchmark.py matrix benchmark/corpus.yml
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Result schema helpers
+# ---------------------------------------------------------------------------
+
+
+def result_path(
+    output_dir: Path, repo: str, provider: str, model: str, focus: str, run: int
+) -> Path:
+    """Return the output path for a single benchmark result file."""
+    model_safe = model.replace("/", "-").replace(":", "-")
+    filename = f"{provider}-{model_safe}-{focus}-run{run}.json"
+    return output_dir / repo / filename
+
+
+def build_result_record(
+    *,
+    repo: str,
+    repo_commit: str,
+    provider: str,
+    model: str,
+    focus: str,
+    run: int,
+    started_at: datetime,
+    completed_at: datetime,
+    wall_clock_seconds: float,
+    error: str | None,
+    tokens: dict,
+    cost_usd: float,
+    findings: list[dict],
+) -> dict:
+    """Return a structured benchmark result dict (the JSON schema)."""
+    return {
+        "meta": {
+            "repo": repo,
+            "repo_commit": repo_commit,
+            "provider": provider,
+            "model": model,
+            "focus": focus,
+            "run": run,
+            "started_at": started_at.isoformat(),
+            "completed_at": completed_at.isoformat(),
+            "wall_clock_seconds": round(wall_clock_seconds, 2),
+            "error": error,
+        },
+        "tokens": tokens,
+        "cost_usd": cost_usd,
+        "findings_count": len(findings),
+        "findings": findings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Matrix expansion
+# ---------------------------------------------------------------------------
+
+
+def build_combinations(matrix: dict) -> list[dict]:
+    """Expand a matrix config dict into a flat list of run parameter dicts."""
+    output_dir = Path(matrix.get("output_dir", "benchmark/results"))
+    rate_limit = matrix.get("rate_limit", {})
+    sleep_s = float(rate_limit.get("sleep_between_runs", 3))
+    backoff_s = float(rate_limit.get("backoff_on_error", 30))
+
+    combos = []
+    for repo_cfg in matrix.get("repos", []):
+        for provider_cfg in matrix.get("providers", []):
+            for model in provider_cfg.get("models", []):
+                for focus in matrix.get("focus", ["all"]):
+                    for run in range(1, int(matrix.get("runs", 1)) + 1):
+                        combos.append(
+                            {
+                                "repo_name": repo_cfg["name"],
+                                "repo_path": repo_cfg["path"],
+                                "repo_commit": repo_cfg.get("commit", ""),
+                                "provider": provider_cfg["name"],
+                                "model": model,
+                                "focus": focus,
+                                "run": run,
+                                "output_dir": output_dir,
+                                "exclude_patterns": repo_cfg.get("exclude", []),
+                                "sleep_s": sleep_s,
+                                "backoff_s": backoff_s,
+                            }
+                        )
+    return combos
+
+
+# ---------------------------------------------------------------------------
+# Single-combination runner
+# ---------------------------------------------------------------------------
+
+
+def run_one(
+    repo_name: str,
+    repo_path: str,
+    repo_commit: str,
+    provider: str,
+    model: str,
+    focus: str,
+    run: int,
+    output_dir: Path,
+    exclude_patterns: list[str] | None = None,
+) -> bool:
+    """Run one benchmark combination and write a result JSON file.
+
+    Returns True if the run executed, False if it was skipped (already done).
+    Raises on unrecoverable errors so callers can apply backoff.
+    """
+    from noxaudit.config import NoxauditConfig, RepoConfig
+    from noxaudit.cost_ledger import CostLedger
+    from noxaudit.runner import run_audit
+
+    out_path = result_path(output_dir, repo_name, provider, model, focus, run)
+    if out_path.exists():
+        print(f"  [SKIP] {repo_name} | {provider}/{model} | {focus} | run{run} — result exists")
+        return False
+
+    print(f"  [RUN ] {repo_name} | {provider}/{model} | focus={focus} | run={run}")
+
+    config = NoxauditConfig(
+        repos=[
+            RepoConfig(
+                name=repo_name,
+                path=repo_path,
+                provider_rotation=[provider],
+                exclude_patterns=exclude_patterns or [],
+            )
+        ],
+        model=model,
+    )
+
+    # Snapshot ledger length so we can isolate the new entry after the run.
+    before_entries = CostLedger.read_entries()
+    before_count = len(before_entries)
+
+    started_at = datetime.now()
+    t0 = time.monotonic()
+    error: str | None = None
+    results = []
+
+    try:
+        results = run_audit(
+            config,
+            repo_name=repo_name,
+            focus_name=focus,
+            provider_name=provider,
+        )
+    except Exception as exc:
+        error = str(exc)
+        print(f"         [ERROR] {error}")
+
+    wall_clock = time.monotonic() - t0
+    completed_at = datetime.now()
+
+    # Read the new ledger entry appended by run_audit (if any).
+    all_entries = CostLedger.read_entries()
+    new_entries = all_entries[before_count:]
+    last_entry = new_entries[-1] if new_entries else {}
+
+    audit_result = results[0] if results else None
+    findings = [f.to_dict() for f in audit_result.findings] if audit_result else []
+
+    record = build_result_record(
+        repo=repo_name,
+        repo_commit=repo_commit,
+        provider=provider,
+        model=model,
+        focus=focus,
+        run=run,
+        started_at=started_at,
+        completed_at=completed_at,
+        wall_clock_seconds=wall_clock,
+        error=error,
+        tokens={
+            "input": last_entry.get("input_tokens", 0),
+            "output": last_entry.get("output_tokens", 0),
+            "cache_read": last_entry.get("cache_read_tokens", 0),
+            "cache_write": last_entry.get("cache_write_tokens", 0),
+        },
+        cost_usd=last_entry.get("cost_estimate_usd", 0.0),
+        findings=findings,
+    )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(record, indent=2))
+
+    status = "ERROR" if error else "OK"
+    cost = record["cost_usd"]
+    print(
+        f"         [{status}] {len(findings)} findings, {wall_clock:.1f}s, ${cost:.4f} → {out_path}"
+    )
+
+    if error:
+        raise RuntimeError(error)
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Matrix runner
+# ---------------------------------------------------------------------------
+
+
+def run_matrix(config_path: Path) -> None:
+    """Run the full benchmark matrix defined in a YAML config file.
+
+    Skips combinations whose output file already exists, enabling resume.
+    """
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f)
+
+    # Support both top-level matrix key and flat config
+    matrix = cfg.get("matrix", cfg)
+    combos = build_combinations(matrix)
+    total = len(combos)
+    output_dir = matrix.get("output_dir", "benchmark/results")
+
+    print(f"Benchmark matrix: {total} combinations")
+    print(f"Output dir:       {output_dir}")
+    print()
+
+    completed = skipped = errors = 0
+
+    for i, combo in enumerate(combos, 1):
+        sleep_s = combo.pop("sleep_s")
+        backoff_s = combo.pop("backoff_s")
+        print(f"[{i}/{total}]", end=" ", flush=True)
+        try:
+            ran = run_one(**combo)
+            if ran:
+                completed += 1
+                if sleep_s > 0:
+                    time.sleep(sleep_s)
+            else:
+                skipped += 1
+        except Exception as exc:
+            errors += 1
+            print(f"         Unhandled error: {exc}")
+            if backoff_s > 0:
+                print(f"         Backing off {backoff_s}s...")
+                time.sleep(backoff_s)
+
+    print()
+    print(f"Done: {completed} completed, {skipped} skipped, {errors} errors")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Noxaudit benchmark runner",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    sub = parser.add_subparsers(dest="command", metavar="COMMAND")
+
+    # --- matrix subcommand ---
+    matrix_cmd = sub.add_parser(
+        "matrix",
+        help="Run full benchmark matrix from a YAML config",
+    )
+    matrix_cmd.add_argument(
+        "config",
+        help="Path to matrix YAML config (e.g. benchmark/corpus.yml)",
+    )
+
+    # --- single subcommand ---
+    single_cmd = sub.add_parser(
+        "single",
+        help="Run a single provider × repo × focus combination",
+    )
+    single_cmd.add_argument("--repo", required=True, help="Repo name (label)")
+    single_cmd.add_argument(
+        "--repo-path", required=True, dest="repo_path", help="Local path to repo"
+    )
+    single_cmd.add_argument(
+        "--repo-commit", default="", dest="repo_commit", help="Pinned commit SHA"
+    )
+    single_cmd.add_argument(
+        "--provider", required=True, help="Provider name (anthropic, gemini, openai)"
+    )
+    single_cmd.add_argument("--model", required=True, help="Model name")
+    single_cmd.add_argument("--focus", default="security", help="Focus area(s): name or 'all'")
+    single_cmd.add_argument("--run", type=int, default=1, help="Run number (default: 1)")
+    single_cmd.add_argument(
+        "--output-dir",
+        default="benchmark/results",
+        dest="output_dir",
+        help="Output directory (default: benchmark/results)",
+    )
+
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.command == "matrix":
+        run_matrix(Path(args.config))
+    elif args.command == "single":
+        try:
+            run_one(
+                repo_name=args.repo,
+                repo_path=args.repo_path,
+                repo_commit=args.repo_commit,
+                provider=args.provider,
+                model=args.model,
+                focus=args.focus,
+                run=args.run,
+                output_dir=Path(args.output_dir),
+            )
+        except RuntimeError:
+            sys.exit(1)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,269 @@
+"""Tests for benchmark runner utility functions."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Import the benchmark script (not a package, so we use importlib)
+# ---------------------------------------------------------------------------
+
+_BENCHMARK_PATH = Path(__file__).parent.parent / "scripts" / "benchmark.py"
+
+
+def _import_benchmark():
+    spec = importlib.util.spec_from_file_location("benchmark", _BENCHMARK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+benchmark = _import_benchmark()
+
+
+# ---------------------------------------------------------------------------
+# result_path
+# ---------------------------------------------------------------------------
+
+
+class TestResultPath:
+    def test_basic(self, tmp_path):
+        p = benchmark.result_path(tmp_path, "noxaudit", "gemini", "gemini-2.0-flash", "security", 1)
+        assert p == tmp_path / "noxaudit" / "gemini-gemini-2.0-flash-security-run1.json"
+
+    def test_model_with_slashes_sanitized(self, tmp_path):
+        p = benchmark.result_path(tmp_path, "repo", "anthropic", "claude/sonnet:v1", "all", 2)
+        assert "/" not in p.name
+        assert ":" not in p.name
+        assert p.name.endswith("-run2.json")
+
+    def test_run_number_in_filename(self, tmp_path):
+        p1 = benchmark.result_path(tmp_path, "repo", "gemini", "gemini-2.0-flash", "security", 1)
+        p2 = benchmark.result_path(tmp_path, "repo", "gemini", "gemini-2.0-flash", "security", 2)
+        assert p1 != p2
+        assert "run1" in p1.name
+        assert "run2" in p2.name
+
+    def test_nested_under_repo_dir(self, tmp_path):
+        p = benchmark.result_path(tmp_path, "my-repo", "gemini", "gemini-2.0-flash", "security", 1)
+        assert p.parent == tmp_path / "my-repo"
+
+
+# ---------------------------------------------------------------------------
+# build_combinations
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCombinations:
+    def _matrix(self, **overrides):
+        base = {
+            "providers": [{"name": "gemini", "models": ["gemini-2.0-flash"]}],
+            "repos": [{"name": "noxaudit", "path": "/tmp/noxaudit"}],
+            "focus": ["security"],
+            "runs": 1,
+            "output_dir": "benchmark/results",
+            "rate_limit": {"sleep_between_runs": 0, "backoff_on_error": 0},
+        }
+        base.update(overrides)
+        return base
+
+    def test_single_combination(self):
+        combos = benchmark.build_combinations(self._matrix())
+        assert len(combos) == 1
+        c = combos[0]
+        assert c["repo_name"] == "noxaudit"
+        assert c["provider"] == "gemini"
+        assert c["model"] == "gemini-2.0-flash"
+        assert c["focus"] == "security"
+        assert c["run"] == 1
+
+    def test_multiple_runs(self):
+        combos = benchmark.build_combinations(self._matrix(runs=3))
+        assert len(combos) == 3
+        assert [c["run"] for c in combos] == [1, 2, 3]
+
+    def test_multiple_focus_areas(self):
+        combos = benchmark.build_combinations(self._matrix(focus=["security", "all"]))
+        assert len(combos) == 2
+        foci = {c["focus"] for c in combos}
+        assert foci == {"security", "all"}
+
+    def test_multiple_providers_and_models(self):
+        matrix = self._matrix(
+            providers=[
+                {"name": "gemini", "models": ["gemini-2.0-flash"]},
+                {
+                    "name": "anthropic",
+                    "models": ["claude-haiku-4-5-20251001", "claude-sonnet-4-5-20250929"],
+                },
+            ]
+        )
+        combos = benchmark.build_combinations(matrix)
+        assert len(combos) == 3  # 1 gemini model + 2 anthropic models
+        providers = [c["provider"] for c in combos]
+        assert providers.count("gemini") == 1
+        assert providers.count("anthropic") == 2
+
+    def test_full_matrix_expansion(self):
+        matrix = self._matrix(
+            providers=[
+                {"name": "gemini", "models": ["gemini-2.0-flash"]},
+                {"name": "anthropic", "models": ["claude-haiku-4-5-20251001"]},
+            ],
+            repos=[
+                {"name": "noxaudit", "path": "/tmp/noxaudit"},
+                {"name": "python-dotenv", "path": "/tmp/python-dotenv"},
+            ],
+            focus=["security", "all"],
+            runs=2,
+        )
+        combos = benchmark.build_combinations(matrix)
+        # 2 providers × 2 repos × 2 focus × 2 runs = 16
+        assert len(combos) == 16
+
+    def test_commit_sha_included(self):
+        matrix = self._matrix(
+            repos=[{"name": "noxaudit", "path": "/tmp/noxaudit", "commit": "abc123"}]
+        )
+        combos = benchmark.build_combinations(matrix)
+        assert combos[0]["repo_commit"] == "abc123"
+
+    def test_missing_commit_defaults_to_empty_string(self):
+        combos = benchmark.build_combinations(self._matrix())
+        assert combos[0]["repo_commit"] == ""
+
+    def test_output_dir_in_combo(self):
+        matrix = self._matrix(output_dir="my/output")
+        combos = benchmark.build_combinations(matrix)
+        assert combos[0]["output_dir"] == Path("my/output")
+
+    def test_rate_limit_defaults(self):
+        matrix = {
+            "providers": [{"name": "gemini", "models": ["gemini-2.0-flash"]}],
+            "repos": [{"name": "noxaudit", "path": "/tmp/noxaudit"}],
+            "focus": ["security"],
+            "runs": 1,
+        }
+        combos = benchmark.build_combinations(matrix)
+        assert combos[0]["sleep_s"] == 3.0
+        assert combos[0]["backoff_s"] == 30.0
+
+
+# ---------------------------------------------------------------------------
+# build_result_record
+# ---------------------------------------------------------------------------
+
+
+class TestBuildResultRecord:
+    def _record(self, **overrides):
+        from datetime import datetime
+
+        base = dict(
+            repo="noxaudit",
+            repo_commit="abc123",
+            provider="gemini",
+            model="gemini-2.0-flash",
+            focus="security",
+            run=1,
+            started_at=datetime(2026, 3, 1, 10, 0, 0),
+            completed_at=datetime(2026, 3, 1, 10, 0, 42),
+            wall_clock_seconds=42.0,
+            error=None,
+            tokens={"input": 1000, "output": 200, "cache_read": 0, "cache_write": 0},
+            cost_usd=0.01,
+            findings=[],
+        )
+        base.update(overrides)
+        return benchmark.build_result_record(**base)
+
+    def test_schema_keys(self):
+        rec = self._record()
+        assert set(rec.keys()) == {"meta", "tokens", "cost_usd", "findings_count", "findings"}
+
+    def test_meta_fields(self):
+        rec = self._record()
+        meta = rec["meta"]
+        assert meta["repo"] == "noxaudit"
+        assert meta["provider"] == "gemini"
+        assert meta["model"] == "gemini-2.0-flash"
+        assert meta["focus"] == "security"
+        assert meta["run"] == 1
+        assert meta["repo_commit"] == "abc123"
+        assert meta["wall_clock_seconds"] == 42.0
+        assert meta["error"] is None
+
+    def test_findings_count_matches_list(self):
+        findings = [{"id": "x", "title": "test"}]
+        rec = self._record(findings=findings)
+        assert rec["findings_count"] == 1
+        assert len(rec["findings"]) == 1
+
+    def test_error_captured(self):
+        rec = self._record(error="Rate limit exceeded")
+        assert rec["meta"]["error"] == "Rate limit exceeded"
+
+    def test_tokens_schema(self):
+        rec = self._record(
+            tokens={"input": 5000, "output": 300, "cache_read": 100, "cache_write": 50}
+        )
+        assert rec["tokens"]["input"] == 5000
+        assert rec["tokens"]["cache_read"] == 100
+
+    def test_json_serializable(self):
+        rec = self._record()
+        # Should not raise
+        json.dumps(rec)
+
+
+# ---------------------------------------------------------------------------
+# run_one — skip logic (no actual API calls)
+# ---------------------------------------------------------------------------
+
+
+class TestRunOneSkipLogic:
+    def test_skips_existing_result(self, tmp_path):
+        # Pre-create the expected output file
+        out = tmp_path / "noxaudit" / "gemini-gemini-2.0-flash-security-run1.json"
+        out.parent.mkdir(parents=True)
+        out.write_text("{}")
+
+        ran = benchmark.run_one(
+            repo_name="noxaudit",
+            repo_path="/nonexistent",
+            repo_commit="",
+            provider="gemini",
+            model="gemini-2.0-flash",
+            focus="security",
+            run=1,
+            output_dir=tmp_path,
+        )
+        assert ran is False
+
+    def test_writes_result_file_on_error(self, tmp_path, tmp_repo):
+        """run_one writes a JSON result file even when the provider call fails."""
+        with pytest.raises(RuntimeError):
+            benchmark.run_one(
+                repo_name="myrepo",
+                repo_path=str(tmp_repo),
+                repo_commit="deadbeef",
+                provider="gemini",
+                model="gemini-2.0-flash",
+                focus="security",
+                run=1,
+                output_dir=tmp_path,
+            )
+        # The result file should still have been written with the error captured.
+        out = tmp_path / "myrepo" / "gemini-gemini-2.0-flash-security-run1.json"
+        assert out.exists()
+        record = json.loads(out.read_text())
+        assert record["meta"]["repo"] == "myrepo"
+        assert record["meta"]["repo_commit"] == "deadbeef"
+        assert record["meta"]["provider"] == "gemini"
+        assert record["meta"]["error"] is not None
+        assert "findings_count" in record
+        assert "tokens" in record


### PR DESCRIPTION
Closes #74
Closes #75

## Summary
## Epic: #67 (OSS Launch)

## Parent: #43

Build the automation that runs noxaudit across the full benchmark matrix and collects structured results.

## Scope

- Create `scripts/benchmark.py` (or `.sh`) that accepts a matrix config and runs `noxaudit run` for each combination
- Matrix: provider × model × repo × focus tier × run number
- Output structured results to `benchmark/results/<repo>/<provider>-<model>-<focus>-run<N>.json`
- Capture: raw findings, cost ledger data, wall-clock time, token 

## Epic: #67 (OSS Launch)

## Parent: #43

Select and pin the benchmark corpus — the repos we'll run all models against.

## Corpus

### Atriumn repos (dogfood — run against our own code)

| Repo | Language | Size | Role |
|---|---|---|---|
| `atriumn/noxaudit` | Python | ~526 KB | Medium, Python, our own product |
| `atriumn/tokencost-dev` | TypeScript | ~3.9 MB | Medium, TS, MCP server |
| `atriumn/cryyer` | TypeScript | ~1 MB | Small, TS, LLM-powered |

### Open source repos

| Repo | Languag

## Changes
01b26d3 feat: add benchmark runner script and corpus definition

`benchmark/.gitignore
benchmark/CORPUS.md
benchmark/corpus.yml
scripts/benchmark.py
tests/test_benchmark.py`

## Acceptance Criteria
- [ ] Script runs a single provider × repo × focus combination end-to-end
- [ ] Script accepts a matrix config (YAML or CLI args) to define the full run
- [ ] Results are written as structured JSON with consistent schema
- [ ] Partial runs can be resumed without re-running completed combos
- [ ] Cost and timing data captured per run
- [ ] 5 repos selected and documented in `benchmark/CORPUS.md`
- [ ] Each repo cloned/pinned at a specific commit SHA for reproducibility
- [ ] Brief rationale for each repo choice (size, language, quality profile)
- [ ] Corpus covers: Python, TypeScript, small/medium/large, clean/messy

## Verification
- Tests: passed
- Branch: `feat/benchmark-build-benchmark-runner-script-74`

Automated PR by Ralph | Model: claude-sonnet-4-6 | Duration: 10m