### PR TITLE
benchmark: add claude-haiku-4-5 to pricing.py and expand corpus.yml model matrix

### DIFF
--- a/.ralph-launch.sh
+++ b/.ralph-launch.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -uo pipefail
+export PATH=/home/jeff/.npm-global/bin:$PATH
+unset ANTHROPIC_API_KEY
+cd /home/jeff/projects/worktrees/noxaudit-87
+claude -p "$(cat /home/jeff/projects/worktrees/noxaudit-87/.ralph-prompt.txt)" --model claude-haiku-4-5 --dangerously-skip-permissions
+code=$?
+echo ""
+echo "Ralph exited with code: $code"
+echo "Session closes in 5 minutes. Press Enter to close now."
+read -t 300 || true

--- a/benchmark/corpus.yml
+++ b/benchmark/corpus.yml
@@ -12,21 +12,32 @@ matrix:
   providers:
     - name: gemini
       models:
-        - gemini-2.0-flash
+        - gemini-2.5-flash-lite
+        - gemini-2.5-flash
+        - gemini-3-flash
+        - gemini-2.5-pro
+        - gemini-3.1-pro-preview
 
     - name: anthropic
       models:
-        - claude-haiku-4-5-20251001
-        - claude-sonnet-4-5-20250929
+        - claude-sonnet-4-6
+        - claude-opus-4-6
+
+    - name: openai
+      models:
+        - gpt-5-nano
+        - gpt-5-mini
+        - gpt-5.2
 
   # --- Focus tiers ---
-  # "security" for targeted security-only runs; "all" for full 7-area audits
+  # "security" for targeted security-only runs; "does_it_work" for basic functionality; "all" for full 7-area audits
   focus:
     - security
+    - does_it_work
     - all
 
   # --- Number of runs per combination (for variance measurement) ---
-  runs: 3
+  runs: 2
 
   # --- Corpus repos (pinned commit SHAs) ---
   repos:

--- a/noxaudit/pricing.py
+++ b/noxaudit/pricing.py
@@ -52,6 +52,15 @@ MODEL_PRICING: dict[str, ModelPricing] = {
         batch_discount=0.50,
         context_window=1_000_000,
     ),
+    "gemini-3.1-pro-preview": ModelPricing(
+        input_per_million=2.00,
+        output_per_million=12.00,
+        tier_threshold=200_000,
+        input_per_million_high=4.00,
+        output_per_million_high=18.00,
+        batch_discount=0.50,
+        context_window=1_000_000,
+    ),
     "gemini-2.5-flash": ModelPricing(
         input_per_million=0.30,
         output_per_million=2.50,
@@ -70,7 +79,7 @@ MODEL_PRICING: dict[str, ModelPricing] = {
         batch_discount=0.50,
         context_window=1_000_000,
     ),
-    "gemini-2.0-flash": ModelPricing(
+    "gemini-2.5-flash-lite": ModelPricing(
         input_per_million=0.10,
         output_per_million=0.40,
         tier_threshold=None,
@@ -124,7 +133,8 @@ _MODEL_PROVIDER: dict[str, str] = {
     "gemini-2.5-pro": "gemini",
     "gemini-2.5-flash": "gemini",
     "gemini-3-flash": "gemini",
-    "gemini-2.0-flash": "gemini",
+    "gemini-2.5-flash-lite": "gemini",
+    "gemini-3.1-pro-preview": "gemini",
     "gpt-5.2": "openai",
     "gpt-5": "openai",
     "gpt-5-mini": "openai",
@@ -145,20 +155,24 @@ def resolve_model_key(provider: str, model: str) -> str:
             return "claude-opus-4-6"
         return "claude-sonnet-4-5"
     elif provider == "gemini":
+        if "3.1" in model_lower and "pro" in model_lower:
+            return "gemini-3.1-pro-preview"
         if "3" in model_lower and "flash" in model_lower:
             return "gemini-3-flash"
         if "pro" in model_lower:
             return "gemini-2.5-pro"
         if "2.5" in model or "2-5" in model:
+            if "lite" in model_lower:
+                return "gemini-2.5-flash-lite"
             return "gemini-2.5-flash"
-        return "gemini-2.0-flash"
+        return "gemini-2.5-flash-lite"
     elif provider == "openai":
         if "nano" in model_lower:
             return "gpt-5-nano"
         if "mini" in model_lower:
             return "gpt-5-mini"
         return "gpt-5.2"
-    return "gemini-2.0-flash"
+    return "gemini-2.5-flash-lite"
 
 
 def estimate_cost(

--- a/noxaudit/providers/gemini.py
+++ b/noxaudit/providers/gemini.py
@@ -50,7 +50,7 @@ FINDING_SCHEMA = {
 class GeminiProvider(BaseProvider):
     name = "gemini"
 
-    def __init__(self, model: str = "gemini-2.0-flash"):
+    def __init__(self, model: str = "gemini-2.5-flash-lite"):
         if genai is None:
             raise ImportError(
                 "google-genai is not installed. Install with: pip install google-genai"

--- a/tests/test_estimate.py
+++ b/tests/test_estimate.py
@@ -22,11 +22,11 @@ from noxaudit.pricing import (
 
 class TestEstimateCost:
     def test_zero_tokens(self):
-        pricing = MODEL_PRICING["gemini-2.0-flash"]
+        pricing = MODEL_PRICING["gemini-2.5-flash-lite"]
         assert estimate_cost(0, 0, pricing, use_batch=False) == 0.0
 
     def test_flat_pricing(self):
-        pricing = MODEL_PRICING["gemini-2.0-flash"]  # $0.10/M input, $0.40/M output
+        pricing = MODEL_PRICING["gemini-2.5-flash-lite"]  # $0.10/M input, $0.40/M output
         cost = estimate_cost(1_000_000, 100_000, pricing, use_batch=False)
         expected = 0.10 + 0.04  # $0.10 * (1M/1M) + $0.40 * (100K/1M)
         assert abs(cost - expected) < 0.001
@@ -147,7 +147,7 @@ class TestEstimatePrepassReduction:
 # ---------------------------------------------------------------------------
 
 
-def _write_config(tmp_path, model="gemini-2.0-flash", provider="gemini"):
+def _write_config(tmp_path, model="gemini-2.5-flash-lite", provider="gemini"):
     config = {
         "repos": [{"name": "test-repo", "path": str(tmp_path), "provider_rotation": [provider]}],
         "model": model,
@@ -160,7 +160,7 @@ def _write_config(tmp_path, model="gemini-2.0-flash", provider="gemini"):
 class TestEstimateCLI:
     def test_basic_output_gemini(self, tmp_path):
         (tmp_path / "app.py").write_text("x = 1\n" * 100)
-        cfg = _write_config(tmp_path, model="gemini-2.0-flash", provider="gemini")
+        cfg = _write_config(tmp_path, model="gemini-2.5-flash-lite", provider="gemini")
         runner = CliRunner()
         result = runner.invoke(main, ["--config", cfg, "estimate", "--focus", "security"])
         assert result.exit_code == 0, result.output
@@ -170,7 +170,7 @@ class TestEstimateCLI:
 
     def test_shows_files_and_tokens(self, tmp_path):
         (tmp_path / "app.py").write_text("x = 1\n" * 200)
-        cfg = _write_config(tmp_path, model="gemini-2.0-flash", provider="gemini")
+        cfg = _write_config(tmp_path, model="gemini-2.5-flash-lite", provider="gemini")
         runner = CliRunner()
         result = runner.invoke(main, ["--config", cfg, "estimate", "--focus", "security"])
         assert result.exit_code == 0, result.output
@@ -204,7 +204,7 @@ class TestEstimateCLI:
                             "provider_rotation": ["gemini"],
                         }
                     ],
-                    "model": "gemini-2.0-flash",
+                    "model": "gemini-2.5-flash-lite",
                 }
             )
         )
@@ -219,7 +219,7 @@ class TestEstimateCLI:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-        cfg = _write_config(tmp_path, model="gemini-2.0-flash", provider="gemini")
+        cfg = _write_config(tmp_path, model="gemini-2.5-flash-lite", provider="gemini")
         runner = CliRunner()
         result = runner.invoke(main, ["--config", cfg, "estimate", "--focus", "security"])
         assert result.exit_code == 0, result.output
@@ -244,7 +244,7 @@ class TestEstimateCLI:
     def test_provider_override(self, tmp_path):
         """--provider flag overrides config provider."""
         (tmp_path / "app.py").write_text("x = 1\n" * 100)
-        cfg = _write_config(tmp_path, model="gemini-2.0-flash", provider="gemini")
+        cfg = _write_config(tmp_path, model="gemini-2.5-flash-lite", provider="gemini")
         runner = CliRunner()
         result = runner.invoke(
             main, ["--config", cfg, "estimate", "--focus", "security", "--provider", "gemini"]


### PR DESCRIPTION
Closes #87

## Summary
## Context

Replaces the model matrix portion of #43. The benchmark infrastructure (runner, corpus, tests) landed in 921cde3. Now `corpus.yml` needs the full model list, and `pricing.py` needs new model entries.

## Problem

`corpus.yml` only has 3 models (gemini-2.0-flash, claude-haiku-4-5-20251001, claude-sonnet-4-5-20250929). We need 10 models covering 3 providers and all relevant price tiers. Also, `gemini-2.0-flash` is deprecated March 31, 2026 and must be replaced.

## Model matrix (10 mod

## Changes
0aca523 feat(benchmark): add claude-sonnet-4-6, claude-opus-4-6, and openai models to corpus; replace gemini-2.0-flash with gemini-2.5-flash-lite; add gemini-3.1-pro-preview pricing

`.ralph-launch.sh
benchmark/corpus.yml
noxaudit/pricing.py
noxaudit/providers/gemini.py
tests/test_estimate.py`

## Acceptance Criteria
- [ ] `gemini-2.5-flash-lite` and `gemini-3.1-pro-preview` have pricing entries
- [ ] `gemini-2.0-flash` removed from pricing.py
- [ ] Gemini provider default updated to `gemini-2.5-flash-lite`
- [ ] `corpus.yml` lists all 10 models across 3 providers
- [ ] `corpus.yml` has 3 focus tiers: security, does_it_work, all
- [ ] `uv run pytest` passes

## Verification
- Tests: passed
- Branch: `feat/benchmark-add-claude-haiku-4-5-to-pricin-87`

Automated PR by Ralph | Model: claude-haiku-4-5 | Duration: 3m