### PR TITLE
benchmark: build scorecard analysis script

### DIFF
--- a/scripts/benchmark_analyze.py
+++ b/scripts/benchmark_analyze.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Benchmark result analysis script for noxaudit.
+
+Reads structured JSON results from benchmark/results/ and produces
+a scorecard markdown report.
+
+Usage:
+    # Generate scorecard from results
+    python scripts/benchmark_analyze.py scorecard benchmark/results/ -o benchmark/scorecard.md
+
+    # Quick summary to stdout
+    python scripts/benchmark_analyze.py summary benchmark/results/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from statistics import mean
+
+try:
+    from noxaudit.pricing import MODEL_PRICING, estimate_cost, resolve_model_key
+
+    _HAS_PRICING = True
+except ImportError:
+    _HAS_PRICING = False
+
+CANARY_REPO = "python-dotenv"
+CANARY_MAX_EXPECTED = 2
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+
+def load_results(results_dir: Path) -> list[dict]:
+    """Load all JSON result files from the results directory."""
+    results = []
+    for path in sorted(results_dir.glob("**/*.json")):
+        try:
+            data = json.loads(path.read_text())
+            results.append(data)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"Warning: could not read {path}: {e}", file=sys.stderr)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Metrics computation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ModelMetrics:
+    model: str
+    provider: str
+    run_count: int = 0
+    findings_per_run: float = 0.0
+    high_sev_rate: float = 0.0
+    cost_sync: float = 0.0
+    cost_batch: float = 0.0
+    cost_per_finding: float = 0.0
+    wall_clock_seconds: float = 0.0
+    consistency: float | None = None  # Jaccard; None if only 1 run per combo
+    unique_findings: int = 0
+    canary_findings: int = -1  # -1 means not tested
+    canary_high_sev: int = -1
+    errors: int = 0
+
+
+def _jaccard(set_a: set, set_b: set) -> float:
+    """Compute Jaccard similarity between two sets."""
+    if not set_a and not set_b:
+        return 1.0
+    union = len(set_a | set_b)
+    return len(set_a & set_b) / union if union > 0 else 1.0
+
+
+def _compute_sync_cost(result: dict) -> float:
+    """Compute sync (non-batch) cost from tokens, falling back to recorded cost_usd."""
+    meta = result.get("meta", {})
+    tokens = result.get("tokens", {})
+    if not _HAS_PRICING or not tokens:
+        return result.get("cost_usd", 0.0)
+    try:
+        model_key = resolve_model_key(meta.get("provider", ""), meta.get("model", ""))
+        pricing = MODEL_PRICING[model_key]
+        return estimate_cost(
+            tokens.get("input", 0),
+            tokens.get("output", 0),
+            pricing,
+            use_batch=False,
+            cache_read_tokens=tokens.get("cache_read", 0),
+            cache_write_tokens=tokens.get("cache_write", 0),
+        )
+    except (KeyError, TypeError):
+        return result.get("cost_usd", 0.0)
+
+
+def _compute_batch_cost(result: dict) -> float:
+    """Compute batch cost from tokens (50% discount), falling back to cost_usd * 0.5."""
+    meta = result.get("meta", {})
+    tokens = result.get("tokens", {})
+    if not _HAS_PRICING or not tokens:
+        return result.get("cost_usd", 0.0) * 0.5
+    try:
+        model_key = resolve_model_key(meta.get("provider", ""), meta.get("model", ""))
+        pricing = MODEL_PRICING[model_key]
+        return estimate_cost(
+            tokens.get("input", 0),
+            tokens.get("output", 0),
+            pricing,
+            use_batch=True,
+            cache_read_tokens=tokens.get("cache_read", 0),
+            cache_write_tokens=tokens.get("cache_write", 0),
+        )
+    except (KeyError, TypeError):
+        return result.get("cost_usd", 0.0) * 0.5
+
+
+def compute_metrics(results: list[dict]) -> dict[str, ModelMetrics]:
+    """Compute per-model aggregated metrics from all benchmark results."""
+    if not results:
+        return {}
+
+    # Group results by model
+    by_model: dict[str, list[dict]] = defaultdict(list)
+    for r in results:
+        model = r.get("meta", {}).get("model", "unknown")
+        by_model[model].append(r)
+
+    # Build cross-model unique-findings index.
+    # combo_findings: {(repo, focus): {model: set_of_ids}}
+    combo_findings: dict[tuple, dict[str, set]] = defaultdict(lambda: defaultdict(set))
+    for r in results:
+        meta = r.get("meta", {})
+        if meta.get("error"):
+            continue
+        repo = meta.get("repo", "")
+        focus = meta.get("focus", "")
+        model = meta.get("model", "unknown")
+        ids = {f.get("id", "") for f in r.get("findings", [])}
+        combo_findings[(repo, focus)][model].update(ids)
+
+    # Per-model unique finding IDs (not found by any other model in same combo)
+    model_unique: dict[str, set] = defaultdict(set)
+    for model_ids in combo_findings.values():
+        all_models = list(model_ids.keys())
+        for model in all_models:
+            other_ids: set = set()
+            for other, ids in model_ids.items():
+                if other != model:
+                    other_ids.update(ids)
+            model_unique[model].update(model_ids[model] - other_ids)
+
+    metrics: dict[str, ModelMetrics] = {}
+
+    for model, model_results in by_model.items():
+        provider = model_results[0].get("meta", {}).get("provider", "unknown")
+        m = ModelMetrics(model=model, provider=provider)
+        m.run_count = len(model_results)
+        m.errors = sum(1 for r in model_results if r.get("meta", {}).get("error"))
+
+        good = [r for r in model_results if not r.get("meta", {}).get("error")]
+        if not good:
+            metrics[model] = m
+            continue
+
+        # Findings per run
+        counts = [r.get("findings_count", 0) for r in good]
+        m.findings_per_run = mean(counts)
+
+        # High severity rate
+        all_findings = [f for r in good for f in r.get("findings", [])]
+        if all_findings:
+            high = sum(
+                1 for f in all_findings if f.get("severity", "").lower() in ("high", "critical")
+            )
+            m.high_sev_rate = high / len(all_findings)
+
+        # Cost (sync and batch, mean per run)
+        sync_costs = [_compute_sync_cost(r) for r in good]
+        batch_costs = [_compute_batch_cost(r) for r in good]
+        m.cost_sync = mean(sync_costs)
+        m.cost_batch = mean(batch_costs)
+
+        # Cost per finding
+        total_findings = sum(counts)
+        total_sync = sum(sync_costs)
+        m.cost_per_finding = total_sync / total_findings if total_findings > 0 else 0.0
+
+        # Wall clock time
+        wall_clocks = [r.get("meta", {}).get("wall_clock_seconds", 0.0) for r in good]
+        m.wall_clock_seconds = mean(wall_clocks)
+
+        # Consistency: mean Jaccard across repeat runs of the same (repo, focus) combo
+        combo_runs: dict[tuple, list[set]] = defaultdict(list)
+        for r in good:
+            meta = r.get("meta", {})
+            key = (meta.get("repo", ""), meta.get("focus", ""))
+            ids = {f.get("id", "") for f in r.get("findings", [])}
+            combo_runs[key].append(ids)
+
+        jaccards = []
+        for run_sets in combo_runs.values():
+            for i in range(len(run_sets)):
+                for j in range(i + 1, len(run_sets)):
+                    jaccards.append(_jaccard(run_sets[i], run_sets[j]))
+        if jaccards:
+            m.consistency = mean(jaccards)
+
+        # Unique findings count
+        m.unique_findings = len(model_unique.get(model, set()))
+
+        # Canary repo metrics
+        canary = [r for r in good if r.get("meta", {}).get("repo") == CANARY_REPO]
+        if canary:
+            canary_findings = [f for r in canary for f in r.get("findings", [])]
+            m.canary_findings = len(canary_findings)
+            m.canary_high_sev = sum(
+                1 for f in canary_findings if f.get("severity", "").lower() in ("high", "critical")
+            )
+
+        metrics[model] = m
+
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# Recommendations
+# ---------------------------------------------------------------------------
+
+
+def build_recommendations(metrics: dict[str, ModelMetrics]) -> str:
+    """Generate recommendation text based on aggregated metrics."""
+    if not metrics:
+        return "_Insufficient data for recommendations. Run the full benchmark matrix._\n"
+
+    # Best for daily batch: lowest batch cost among models with results
+    with_cost = [
+        (m, m.cost_batch) for m in metrics.values() if m.run_count > 0 and m.cost_batch > 0
+    ]
+    best_daily = min(with_cost, key=lambda x: x[1])[0] if with_cost else None
+
+    # Best for monthly deep dives: highest findings/run
+    by_depth = sorted(
+        (m for m in metrics.values() if m.run_count > 0),
+        key=lambda m: m.findings_per_run,
+        reverse=True,
+    )
+    best_deep = by_depth[0] if by_depth else None
+
+    lines = []
+    if best_daily:
+        lines.append(
+            f"- **Daily batch audits**: use `{best_daily.model}` ({best_daily.provider})"
+            f" — ${best_daily.cost_batch:.4f}/run batch cost"
+        )
+    if best_deep and (not best_daily or best_deep.model != best_daily.model):
+        lines.append(
+            f"- **Monthly deep dives**: use `{best_deep.model}` ({best_deep.provider})"
+            f" — {best_deep.findings_per_run:.1f} findings/run"
+        )
+    elif best_deep and best_daily and best_deep.model == best_daily.model:
+        lines.append(f"- **Monthly deep dives**: `{best_deep.model}` also leads on finding depth")
+
+    if not lines:
+        return "_Insufficient data for recommendations. Run the full benchmark matrix._\n"
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _fmt_cost(cost: float) -> str:
+    if cost <= 0:
+        return "n/a"
+    if cost < 0.0001:
+        return f"${cost:.6f}"
+    return f"${cost:.4f}"
+
+
+def _fmt_pct(rate: float) -> str:
+    return f"{rate * 100:.1f}%"
+
+
+def _fmt_time(seconds: float) -> str:
+    if seconds <= 0:
+        return "n/a"
+    return f"{seconds:.1f}s"
+
+
+def _fmt_consistency(c: float | None) -> str:
+    return "n/a" if c is None else f"{c:.2f}"
+
+
+def _canary_status(findings: int, high_sev: int) -> str:
+    if findings < 0:
+        return "—"
+    if high_sev > 0:
+        return "⚠ HIGH SEV"
+    if findings > CANARY_MAX_EXPECTED:
+        return "⚠ WARN"
+    return "OK"
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+
+def generate_scorecard(metrics: dict[str, ModelMetrics], generated_at: str = "") -> str:
+    """Generate the markdown scorecard from aggregated metrics."""
+    if not generated_at:
+        generated_at = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    lines = [
+        "# Noxaudit Benchmark Scorecard",
+        "",
+        f"Generated: {generated_at}",
+        "",
+        f"Canary repo: `{CANARY_REPO}` (expected ≤ {CANARY_MAX_EXPECTED} low-severity findings"
+        " — higher counts or high severity may indicate hallucinations)",
+        "",
+    ]
+
+    if not metrics:
+        lines.append("_No benchmark results found._")
+        return "\n".join(lines)
+
+    sorted_models = sorted(metrics.values(), key=lambda m: (m.provider, m.model))
+
+    # --- Comparison matrix ---
+    lines += [
+        "## Comparison Matrix",
+        "",
+        "| Model | Provider | Runs | Findings/run | High sev% | Cost/run (sync) | Cost/run (batch) | Cost/finding | Wall clock | Consistency | Unique finds |",
+        "|-------|----------|------|-------------|-----------|-----------------|------------------|-------------|------------|-------------|--------------|",
+    ]
+    for m in sorted_models:
+        row = " | ".join(
+            [
+                m.model,
+                m.provider,
+                str(m.run_count),
+                f"{m.findings_per_run:.1f}",
+                _fmt_pct(m.high_sev_rate),
+                _fmt_cost(m.cost_sync),
+                _fmt_cost(m.cost_batch),
+                _fmt_cost(m.cost_per_finding),
+                _fmt_time(m.wall_clock_seconds),
+                _fmt_consistency(m.consistency),
+                str(m.unique_findings),
+            ]
+        )
+        lines.append(f"| {row} |")
+
+    lines += ["", ""]
+
+    # --- Hallucination canary ---
+    lines += [
+        f"## Hallucination Canary (`{CANARY_REPO}`)",
+        "",
+        "| Model | Provider | Findings | High sev | Status |",
+        "|-------|----------|----------|----------|--------|",
+    ]
+    for m in sorted_models:
+        count = "—" if m.canary_findings < 0 else str(m.canary_findings)
+        high = "—" if m.canary_high_sev < 0 else str(m.canary_high_sev)
+        status = _canary_status(m.canary_findings, m.canary_high_sev)
+        lines.append(f"| {m.model} | {m.provider} | {count} | {high} | {status} |")
+
+    lines += ["", ""]
+
+    # --- Recommendations ---
+    lines += [
+        "## Recommendations",
+        "",
+        build_recommendations(metrics),
+    ]
+
+    return "\n".join(lines)
+
+
+def print_summary(metrics: dict[str, ModelMetrics]) -> None:
+    """Print a quick summary table to stdout."""
+    if not metrics:
+        print("No benchmark results found.")
+        return
+
+    sorted_models = sorted(metrics.values(), key=lambda m: (m.provider, m.model))
+
+    print(f"\nBenchmark Summary — {len(sorted_models)} models\n")
+    header = (
+        f"{'Model':<30} {'Provider':<12} {'Runs':>4} {'Findings/run':>12}"
+        f" {'Cost/run(batch)':>15} {'Consistency':>12}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for m in sorted_models:
+        cons = f"{m.consistency:.2f}" if m.consistency is not None else "n/a"
+        print(
+            f"{m.model:<30} {m.provider:<12} {m.run_count:>4}"
+            f" {m.findings_per_run:>12.1f} {_fmt_cost(m.cost_batch):>15} {cons:>12}"
+        )
+
+    print()
+    print(build_recommendations(metrics))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Noxaudit benchmark result analyzer",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    sub = parser.add_subparsers(dest="command", metavar="COMMAND")
+
+    scorecard_cmd = sub.add_parser(
+        "scorecard",
+        help="Generate scorecard markdown from benchmark results",
+    )
+    scorecard_cmd.add_argument(
+        "results_dir",
+        help="Directory containing benchmark result JSON files",
+    )
+    scorecard_cmd.add_argument(
+        "-o",
+        "--output",
+        default="benchmark/scorecard.md",
+        help="Output path for scorecard markdown (default: benchmark/scorecard.md)",
+    )
+
+    summary_cmd = sub.add_parser(
+        "summary",
+        help="Print quick summary to stdout",
+    )
+    summary_cmd.add_argument(
+        "results_dir",
+        help="Directory containing benchmark result JSON files",
+    )
+
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.command == "scorecard":
+        results_dir = Path(args.results_dir)
+        if not results_dir.exists():
+            print(f"Error: results directory does not exist: {results_dir}", file=sys.stderr)
+            sys.exit(1)
+        results = load_results(results_dir)
+        metrics = compute_metrics(results)
+        scorecard = generate_scorecard(metrics)
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(scorecard)
+        print(f"Scorecard written to {output_path}")
+        print(f"({len(results)} result files, {len(metrics)} models)")
+
+    elif args.command == "summary":
+        results_dir = Path(args.results_dir)
+        if not results_dir.exists():
+            print(f"Error: results directory does not exist: {results_dir}", file=sys.stderr)
+            sys.exit(1)
+        results = load_results(results_dir)
+        metrics = compute_metrics(results)
+        print_summary(metrics)
+
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_benchmark_analyze.py
+++ b/tests/test_benchmark_analyze.py
@@ -1,0 +1,562 @@
+"""Tests for scripts/benchmark_analyze.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Import the script via importlib (same pattern as test_benchmark.py)
+# ---------------------------------------------------------------------------
+
+_ANALYZE_PATH = Path(__file__).parent.parent / "scripts" / "benchmark_analyze.py"
+
+
+def _import_analyze():
+    spec = importlib.util.spec_from_file_location("benchmark_analyze", _ANALYZE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["benchmark_analyze"] = mod  # must register before exec for @dataclass
+    spec.loader.exec_module(mod)
+    return mod
+
+
+analyze = _import_analyze()
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_result(
+    repo="noxaudit",
+    provider="gemini",
+    model="gemini-2.5-flash",
+    focus="security",
+    run=1,
+    findings=None,
+    cost_usd=0.01,
+    wall_clock_seconds=30.0,
+    error=None,
+    input_tokens=1000,
+    output_tokens=200,
+):
+    if findings is None:
+        findings = []
+    return {
+        "meta": {
+            "repo": repo,
+            "repo_commit": "abc123",
+            "provider": provider,
+            "model": model,
+            "focus": focus,
+            "run": run,
+            "started_at": "2026-03-01T10:00:00",
+            "completed_at": "2026-03-01T10:00:30",
+            "wall_clock_seconds": wall_clock_seconds,
+            "error": error,
+        },
+        "tokens": {
+            "input": input_tokens,
+            "output": output_tokens,
+            "cache_read": 0,
+            "cache_write": 0,
+        },
+        "cost_usd": cost_usd,
+        "findings_count": len(findings),
+        "findings": findings,
+    }
+
+
+def _make_finding(fid="f001", severity="high", file="src/app.py"):
+    return {
+        "id": fid,
+        "severity": severity,
+        "file": file,
+        "line": 10,
+        "title": f"Issue {fid}",
+        "description": "A finding",
+        "suggestion": "Fix it",
+    }
+
+
+# ---------------------------------------------------------------------------
+# load_results
+# ---------------------------------------------------------------------------
+
+
+class TestLoadResults:
+    def test_loads_json_files(self, tmp_path):
+        result = _make_result()
+        (tmp_path / "noxaudit").mkdir()
+        (tmp_path / "noxaudit" / "gemini-gemini-2.5-flash-security-run1.json").write_text(
+            json.dumps(result)
+        )
+        loaded = analyze.load_results(tmp_path)
+        assert len(loaded) == 1
+        assert loaded[0]["meta"]["repo"] == "noxaudit"
+
+    def test_loads_nested_subdirectories(self, tmp_path):
+        (tmp_path / "repo1").mkdir()
+        (tmp_path / "repo2").mkdir()
+        (tmp_path / "repo1" / "result1.json").write_text(json.dumps(_make_result(repo="repo1")))
+        (tmp_path / "repo2" / "result2.json").write_text(json.dumps(_make_result(repo="repo2")))
+        loaded = analyze.load_results(tmp_path)
+        assert len(loaded) == 2
+
+    def test_skips_invalid_json(self, tmp_path, capsys):
+        (tmp_path / "bad.json").write_text("not json {{")
+        (tmp_path / "good.json").write_text(json.dumps(_make_result()))
+        loaded = analyze.load_results(tmp_path)
+        assert len(loaded) == 1
+        assert "Warning" in capsys.readouterr().err
+
+    def test_returns_empty_for_empty_dir(self, tmp_path):
+        assert analyze.load_results(tmp_path) == []
+
+    def test_partial_results_ok(self, tmp_path):
+        """Works with partial results (not full matrix)."""
+        (tmp_path / "result.json").write_text(json.dumps(_make_result(model="model-a")))
+        loaded = analyze.load_results(tmp_path)
+        assert len(loaded) == 1
+
+
+# ---------------------------------------------------------------------------
+# _jaccard
+# ---------------------------------------------------------------------------
+
+
+class TestJaccard:
+    def test_identical_sets(self):
+        assert analyze._jaccard({"a", "b"}, {"a", "b"}) == 1.0
+
+    def test_disjoint_sets(self):
+        assert analyze._jaccard({"a"}, {"b"}) == 0.0
+
+    def test_partial_overlap(self):
+        # |{a,b} ∩ {b,c}| / |{a,b} ∪ {b,c}| = 1/3
+        result = analyze._jaccard({"a", "b"}, {"b", "c"})
+        assert abs(result - 1 / 3) < 1e-9
+
+    def test_both_empty(self):
+        assert analyze._jaccard(set(), set()) == 1.0
+
+    def test_one_empty(self):
+        assert analyze._jaccard({"a"}, set()) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# compute_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMetrics:
+    def test_empty_returns_empty(self):
+        assert analyze.compute_metrics([]) == {}
+
+    def test_basic_model_detected(self):
+        results = [_make_result(model="gemini-2.5-flash")]
+        m = analyze.compute_metrics(results)
+        assert "gemini-2.5-flash" in m
+
+    def test_run_count(self):
+        results = [_make_result(run=1), _make_result(run=2)]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].run_count == 2
+
+    def test_findings_per_run_mean(self):
+        findings_a = [_make_finding("f1"), _make_finding("f2")]
+        findings_b = [_make_finding("f3")]
+        results = [
+            _make_result(run=1, findings=findings_a),
+            _make_result(run=2, findings=findings_b),
+        ]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].findings_per_run == 1.5  # mean([2, 1])
+
+    def test_high_sev_rate(self):
+        findings = [
+            _make_finding("f1", severity="high"),
+            _make_finding("f2", severity="low"),
+            _make_finding("f3", severity="medium"),
+            _make_finding("f4", severity="high"),
+        ]
+        results = [_make_result(findings=findings)]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].high_sev_rate == 0.5  # 2/4
+
+    def test_critical_severity_counted_as_high(self):
+        findings = [
+            _make_finding("f1", severity="critical"),
+            _make_finding("f2", severity="low"),
+        ]
+        results = [_make_result(findings=findings)]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].high_sev_rate == 0.5
+
+    def test_wall_clock_mean(self):
+        results = [
+            _make_result(run=1, wall_clock_seconds=10.0),
+            _make_result(run=2, wall_clock_seconds=20.0),
+        ]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].wall_clock_seconds == 15.0
+
+    def test_error_count(self):
+        results = [
+            _make_result(run=1, error=None),
+            _make_result(run=2, error="Rate limit exceeded"),
+        ]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].errors == 1
+
+    def test_error_results_excluded_from_metrics(self):
+        """Error results don't pollute findings/run count."""
+        results = [
+            _make_result(run=1, findings=[_make_finding("f1")], error=None),
+            _make_result(run=2, findings=[], error="boom"),
+        ]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].findings_per_run == 1.0  # only run1 counts
+
+    def test_consistency_same_findings(self):
+        findings = [_make_finding("f1"), _make_finding("f2")]
+        results = [
+            _make_result(run=1, findings=findings),
+            _make_result(run=2, findings=findings),
+        ]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].consistency == 1.0
+
+    def test_consistency_different_findings(self):
+        results = [
+            _make_result(run=1, findings=[_make_finding("f1")]),
+            _make_result(run=2, findings=[_make_finding("f2")]),
+        ]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].consistency == 0.0
+
+    def test_consistency_none_for_single_run(self):
+        """Consistency is None when only 1 run per (repo, focus) combo."""
+        results = [_make_result(run=1)]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].consistency is None
+
+    def test_consistency_partial_overlap(self):
+        """Jaccard of {f1,f2} and {f1,f3} = 1/3."""
+        results = [
+            _make_result(run=1, findings=[_make_finding("f1"), _make_finding("f2")]),
+            _make_result(run=2, findings=[_make_finding("f1"), _make_finding("f3")]),
+        ]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].consistency is not None
+        assert abs(m["gemini-2.5-flash"].consistency - 1 / 3) < 1e-9
+
+    def test_canary_repo_metrics(self):
+        results = [
+            _make_result(
+                repo=analyze.CANARY_REPO,
+                findings=[_make_finding("f1", severity="low")],
+            )
+        ]
+        m = analyze.compute_metrics(results)
+        mm = m["gemini-2.5-flash"]
+        assert mm.canary_findings == 1
+        assert mm.canary_high_sev == 0
+
+    def test_canary_high_sev_flagged(self):
+        results = [
+            _make_result(
+                repo=analyze.CANARY_REPO,
+                findings=[_make_finding("f1", severity="high")],
+            )
+        ]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].canary_high_sev == 1
+
+    def test_canary_not_tested_is_minus_one(self):
+        results = [_make_result(repo="some-other-repo")]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].canary_findings == -1
+        assert m["gemini-2.5-flash"].canary_high_sev == -1
+
+    def test_unique_findings_cross_model(self):
+        results = [
+            _make_result(
+                model="model-a",
+                findings=[_make_finding("f-unique-a"), _make_finding("f-shared")],
+            ),
+            _make_result(
+                model="model-b",
+                findings=[_make_finding("f-unique-b"), _make_finding("f-shared")],
+            ),
+        ]
+        m = analyze.compute_metrics(results)
+        assert m["model-a"].unique_findings == 1
+        assert m["model-b"].unique_findings == 1
+
+    def test_unique_findings_all_shared(self):
+        findings = [_make_finding("f1"), _make_finding("f2")]
+        results = [
+            _make_result(model="model-a", findings=findings),
+            _make_result(model="model-b", findings=findings),
+        ]
+        m = analyze.compute_metrics(results)
+        assert m["model-a"].unique_findings == 0
+        assert m["model-b"].unique_findings == 0
+
+    def test_multiple_models(self):
+        results = [
+            _make_result(model="model-a", provider="gemini"),
+            _make_result(model="model-b", provider="anthropic"),
+        ]
+        m = analyze.compute_metrics(results)
+        assert len(m) == 2
+        assert "model-a" in m
+        assert "model-b" in m
+
+    def test_cost_per_finding_zero_when_no_findings(self):
+        results = [_make_result(findings=[], cost_usd=0.01)]
+        m = analyze.compute_metrics(results)
+        assert m["gemini-2.5-flash"].cost_per_finding == 0.0
+
+    def test_partial_results_different_repos(self):
+        """Works when only some repos have results (partial matrix)."""
+        results = [_make_result(repo="repo-a")]
+        m = analyze.compute_metrics(results)
+        assert "gemini-2.5-flash" in m
+
+    def test_all_errors_model_still_present(self):
+        """A model with only errors still appears in metrics with run_count set."""
+        results = [_make_result(error="boom")]
+        m = analyze.compute_metrics(results)
+        assert "gemini-2.5-flash" in m
+        assert m["gemini-2.5-flash"].run_count == 1
+        assert m["gemini-2.5-flash"].errors == 1
+
+
+# ---------------------------------------------------------------------------
+# generate_scorecard
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateScorecard:
+    def _two_model_metrics(self):
+        results = [
+            _make_result(
+                model="gemini-2.5-flash",
+                provider="gemini",
+                repo=analyze.CANARY_REPO,
+                findings=[_make_finding("f1", severity="low")],
+                cost_usd=0.01,
+            ),
+            _make_result(
+                model="claude-opus-4-6",
+                provider="anthropic",
+                repo=analyze.CANARY_REPO,
+                findings=[_make_finding("f2", severity="high")],
+                cost_usd=0.50,
+            ),
+        ]
+        return analyze.compute_metrics(results)
+
+    def test_returns_string(self):
+        sc = analyze.generate_scorecard(self._two_model_metrics())
+        assert isinstance(sc, str)
+
+    def test_contains_header(self):
+        sc = analyze.generate_scorecard(self._two_model_metrics())
+        assert "# Noxaudit Benchmark Scorecard" in sc
+
+    def test_contains_model_names(self):
+        sc = analyze.generate_scorecard(self._two_model_metrics())
+        assert "gemini-2.5-flash" in sc
+        assert "claude-opus-4-6" in sc
+
+    def test_contains_comparison_matrix_section(self):
+        sc = analyze.generate_scorecard(self._two_model_metrics())
+        assert "## Comparison Matrix" in sc
+
+    def test_contains_canary_section(self):
+        sc = analyze.generate_scorecard(self._two_model_metrics())
+        assert "## Hallucination Canary" in sc
+
+    def test_contains_recommendations_section(self):
+        sc = analyze.generate_scorecard(self._two_model_metrics())
+        assert "## Recommendations" in sc
+
+    def test_canary_warn_for_high_sev(self):
+        sc = analyze.generate_scorecard(self._two_model_metrics())
+        assert "⚠" in sc
+
+    def test_canary_ok_status(self):
+        results = [
+            _make_result(
+                model="gemini-2.5-flash",
+                repo=analyze.CANARY_REPO,
+                findings=[_make_finding("f1", severity="low")],
+            )
+        ]
+        m = analyze.compute_metrics(results)
+        sc = analyze.generate_scorecard(m)
+        assert "OK" in sc
+
+    def test_empty_metrics_handled(self):
+        sc = analyze.generate_scorecard({})
+        assert "No benchmark results found" in sc
+
+    def test_generated_at_included(self):
+        sc = analyze.generate_scorecard(self._two_model_metrics(), generated_at="2026-03-01")
+        assert "2026-03-01" in sc
+
+    def test_both_sync_and_batch_cost_columns(self):
+        sc = analyze.generate_scorecard(self._two_model_metrics())
+        assert "sync" in sc.lower()
+        assert "batch" in sc.lower()
+
+    def test_not_tested_canary_shows_dash(self):
+        """Models that didn't run against the canary show '—'."""
+        results = [_make_result(model="model-a", repo="other-repo")]
+        m = analyze.compute_metrics(results)
+        sc = analyze.generate_scorecard(m)
+        assert "—" in sc
+
+
+# ---------------------------------------------------------------------------
+# build_recommendations
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRecommendations:
+    def test_empty_metrics_returns_fallback(self):
+        rec = analyze.build_recommendations({})
+        assert "Insufficient" in rec
+
+    def test_returns_string(self):
+        results = [_make_result(cost_usd=0.01, findings=[_make_finding("f1")])]
+        m = analyze.compute_metrics(results)
+        rec = analyze.build_recommendations(m)
+        assert isinstance(rec, str)
+
+    def test_mentions_daily_batch(self):
+        results = [
+            _make_result(model="model-cheap", cost_usd=0.001, findings=[_make_finding("f1")]),
+            _make_result(model="model-expensive", cost_usd=1.0, findings=[_make_finding("f2")]),
+        ]
+        m = analyze.compute_metrics(results)
+        rec = analyze.build_recommendations(m)
+        assert "daily" in rec.lower() or "batch" in rec.lower()
+
+    def test_prefers_cheaper_for_daily(self):
+        results = [
+            _make_result(
+                model="model-cheap",
+                provider="gemini",
+                cost_usd=0.001,
+                input_tokens=100,
+                output_tokens=10,
+            ),
+            _make_result(
+                model="model-expensive",
+                provider="anthropic",
+                cost_usd=1.0,
+                input_tokens=100,
+                output_tokens=10,
+            ),
+        ]
+        m = analyze.compute_metrics(results)
+        rec = analyze.build_recommendations(m)
+        assert "model-cheap" in rec
+
+
+# ---------------------------------------------------------------------------
+# _canary_status helper
+# ---------------------------------------------------------------------------
+
+
+class TestCanaryStatus:
+    def test_not_tested(self):
+        assert analyze._canary_status(-1, -1) == "—"
+
+    def test_ok(self):
+        assert analyze._canary_status(1, 0) == "OK"
+
+    def test_warn_too_many(self):
+        assert analyze._canary_status(analyze.CANARY_MAX_EXPECTED + 1, 0) == "⚠ WARN"
+
+    def test_high_sev(self):
+        assert analyze._canary_status(1, 1) == "⚠ HIGH SEV"
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def _write_result(self, results_dir: Path, **kwargs) -> None:
+        results_dir.mkdir(parents=True, exist_ok=True)
+        path = results_dir / "result.json"
+        path.write_text(json.dumps(_make_result(**kwargs)))
+
+    def _run_main(self, argv: list[str]) -> int | None:
+        old_argv = sys.argv
+        sys.argv = argv
+        try:
+            analyze.main()
+            return 0
+        except SystemExit as e:
+            return e.code
+        finally:
+            sys.argv = old_argv
+
+    def test_scorecard_command_writes_file(self, tmp_path):
+        results_dir = tmp_path / "results"
+        self._write_result(results_dir, findings=[_make_finding("f1")])
+        output = tmp_path / "scorecard.md"
+
+        code = self._run_main(
+            ["benchmark_analyze.py", "scorecard", str(results_dir), "-o", str(output)]
+        )
+        assert code in (0, None)
+        assert output.exists()
+        assert "Noxaudit Benchmark Scorecard" in output.read_text()
+
+    def test_scorecard_creates_parent_dirs(self, tmp_path):
+        results_dir = tmp_path / "results"
+        self._write_result(results_dir)
+        output = tmp_path / "nested" / "deep" / "scorecard.md"
+
+        self._run_main(["benchmark_analyze.py", "scorecard", str(results_dir), "-o", str(output)])
+        assert output.exists()
+
+    def test_scorecard_nonexistent_dir_exits(self, tmp_path):
+        code = self._run_main(
+            [
+                "benchmark_analyze.py",
+                "scorecard",
+                str(tmp_path / "nonexistent"),
+                "-o",
+                str(tmp_path / "out.md"),
+            ]
+        )
+        assert code not in (0, None)
+
+    def test_summary_command_prints_output(self, tmp_path, capsys):
+        results_dir = tmp_path / "results"
+        self._write_result(results_dir, findings=[_make_finding("f1")])
+
+        self._run_main(["benchmark_analyze.py", "summary", str(results_dir)])
+
+        out = capsys.readouterr().out
+        assert "gemini-2.5-flash" in out
+
+    def test_summary_nonexistent_dir_exits(self, tmp_path):
+        code = self._run_main(["benchmark_analyze.py", "summary", str(tmp_path / "nonexistent")])
+        assert code not in (0, None)
+
+    def test_no_command_exits_nonzero(self):
+        code = self._run_main(["benchmark_analyze.py"])
+        assert code not in (0, None)


### PR DESCRIPTION
Closes #88

## Summary
## Context

Replaces the analysis/deliverables portion of #43. The benchmark runner (`scripts/benchmark.py`) writes structured JSON to `benchmark/results/`. We need a script that reads those results and produces a scorecard.

## Problem

No tooling exists to aggregate benchmark results into a comparison. Manual analysis of 45+ JSON files isn't practical.

## Work

Create `scripts/benchmark_analyze.py` that:

1. **Reads** all `benchmark/results/**/*.json` files
2. **Computes per-model metrics**:


## Changes
91394e5 feat(benchmark): add scorecard analysis script

`scripts/benchmark_analyze.py
tests/test_benchmark_analyze.py`

## Acceptance Criteria
- [ ] `scripts/benchmark_analyze.py` reads result JSON files
- [ ] Scorecard includes: findings/run, cost/run (sync + batch), cost/finding, consistency, hallucination score
- [ ] Outputs markdown to `benchmark/scorecard.md`
- [ ] Works with partial results (doesn't require full matrix to be complete)
- [ ] `uv run pytest` passes (add tests in `tests/test_benchmark_analyze.py`)

## Verification
- Tests: passed
- Branch: `feat/benchmark-build-scorecard-analysis-scrip-88`

Automated PR by Ralph | Model: claude-sonnet-4-6 | Duration: 8m