### PR TITLE
fix: remove "nightly" branding from tagline and core messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
 </p>
 
-<p align="center">Nightly AI-powered codebase audits with rotating focus areas, multi-provider support, and decision memory.</p>
+<p align="center">AI-powered codebase audits with rotating focus areas, multi-provider support, and decision memory.</p>
 
 **The problem**: Codebases drift. Security issues creep in, docs go stale, patterns diverge, dead code accumulates. Linters catch syntax — they miss semantics.
 
-**The solution**: Noxaudit runs a focused AI audit every night, rotating through different concerns. It remembers what you've already reviewed so only genuinely new findings surface.
+**The solution**: Noxaudit runs focused AI audits, rotating through different concerns. It remembers what you've already reviewed so only genuinely new findings surface.
 
 ## How It Works
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -1,5 +1,5 @@
 name: 'Noxaudit'
-description: 'Nightly AI-powered codebase audits with rotating focus areas'
+description: 'AI-powered codebase audits with rotating focus areas'
 branding:
   icon: 'shield'
   color: 'blue'

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ hide:
 
 # Noxaudit
 
-**Nightly AI-powered codebase audits with rotating focus areas, multi-provider support, and decision memory.**
+**AI-powered codebase audits with rotating focus areas, multi-provider support, and decision memory.**
 
 [Get Started](getting-started/installation.md){ .md-button .md-button--primary }
 [View on GitHub](https://github.com/atriumn/noxaudit){ .md-button }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Noxaudit
 site_url: https://docs.noxaudit.com
-site_description: Nightly AI-powered codebase audits with rotating focus areas, multi-provider support, and decision memory.
+site_description: AI-powered codebase audits with rotating focus areas, multi-provider support, and decision memory.
 repo_url: https://github.com/atriumn/noxaudit
 repo_name: atriumn/noxaudit
 

--- a/noxaudit/__init__.py
+++ b/noxaudit/__init__.py
@@ -1,3 +1,3 @@
-"""Noxaudit: Nightly AI-powered codebase audits."""
+"""Noxaudit: AI-powered codebase audits."""
 
 __version__ = "1.1.1"

--- a/noxaudit/cli.py
+++ b/noxaudit/cli.py
@@ -141,7 +141,7 @@ def _display_cost_summary() -> None:
 @click.option("--config", "-c", "config_path", default=None, help="Path to noxaudit.yml")
 @click.pass_context
 def main(ctx, config_path):
-    """Noxaudit: Nightly AI-powered codebase audits."""
+    """Noxaudit: AI-powered codebase audits."""
     ctx.ensure_object(dict)
     ctx.obj["config_path"] = config_path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "noxaudit"
 version = "1.1.1"
-description = "Nightly AI-powered codebase audits with rotating focus areas, multi-provider support, and decision memory"
+description = "AI-powered codebase audits with rotating focus areas, multi-provider support, and decision memory"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -833,7 +833,7 @@ wheels = [
 
 [[package]]
 name = "noxaudit"
-version = "0.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Closes #103

## Summary
## Problem

The tagline and core messaging say "Nightly AI-powered codebase audits" throughout the codebase. This implies users need cron jobs and that the tool is designed for one specific cadence.

The actual model:
- **Open source CLI**: on-demand — run it when you want
- **SaaS (future)**: we run it for clients on a schedule we control

"Nightly" was accurate when this was an internal cron job, but it's misleading now for an open source tool.

## Changes

Replace "Nightly AI-powered codebase

## Changes
01b15a7 fix: remove "nightly" branding from tagline and core messaging

`README.md
action/action.yml
docs/index.md
mkdocs.yml
noxaudit/__init__.py
noxaudit/cli.py
pyproject.toml
uv.lock`

## Acceptance Criteria
- [ ] `pyproject.toml:8` — package description
- [ ] `noxaudit/__init__.py:1` — module docstring
- [ ] `noxaudit/cli.py:144` — CLI help text
- [ ] `README.md:13` — tagline
- [ ] `README.md:17` — "runs a focused AI audit every night" → "runs focused AI audits"
- [ ] `mkdocs.yml:3` — site_description
- [ ] `docs/index.md:12` — docs tagline
- [ ] `action/action.yml:2` — GitHub Action description

## Verification
- Tests: passed
- Branch: `feat/fix-remove-nightly-branding-from-tagline-103`

Automated PR by Ralph | Model: claude-haiku-4-5 | Duration: 2m