### PR TITLE
docs: reframe scheduling as optional, not the default path

### DIFF
--- a/docs/getting-started/first-audit.md
+++ b/docs/getting-started/first-audit.md
@@ -130,9 +130,9 @@ Cost (last 30 days):
   Projected monthly:   ~$4.20
 ```
 
-## Step 7: Set Up Nightly Runs
+## Step 7: Automate Your Audits
 
-Once you're happy with the results, automate it. See the [GitHub Actions integration](../integrations/github-actions.md) or set up a cron job:
+Once you're happy with the results, you can optionally automate it. See the [GitHub Actions integration](../integrations/github-actions.md) or set up a cron job:
 
 ```bash
 # Run all focus areas daily at 6 AM

--- a/docs/guides/cost-management.md
+++ b/docs/guides/cost-management.md
@@ -1,6 +1,6 @@
 # Cost Management
 
-Noxaudit is designed to be cheap enough to run daily. This guide covers estimation, budget controls, cost tracking, and optimization strategies.
+Noxaudit is designed to be cheap enough to run frequently. This guide covers estimation, budget controls, cost tracking, and optimization strategies.
 
 ## Estimating Cost
 
@@ -16,7 +16,7 @@ noxaudit estimate --focus security
   Files:     42 files, 87K tokens
   Provider:  openai (gpt-5-mini)
 
-  Cost estimate: ~$0.03
+  Cost estimate: ~$0.03 per run
     Batch API 50% discount applied.
 
   Alternatives:
@@ -24,16 +24,16 @@ noxaudit estimate --focus security
     gemini (gemini-2.5-flash)                ~$0.03   similar cost
     anthropic (claude-sonnet-4-6)            ~$0.14   more expensive — deeper analysis
 
-  Monthly estimate: ~$0.90 (assuming daily runs)
-  Monthly with gpt-5-nano: ~$0.30
+  Running daily: ~$0.90/month
+  Running daily with gpt-5-nano: ~$0.30/month
 ```
 
 The estimate includes:
 
 - File and token counts
-- Cost with your current model (including batch discounts)
+- Cost per run with your current model (including batch discounts)
 - Cheaper alternatives with savings percentages
-- Monthly projection assuming daily runs
+- Monthly cost projections based on different run frequencies
 - Pre-pass potential for large codebases
 
 ## Budget Controls
@@ -76,9 +76,9 @@ Cost tracking uses retroactive repricing — stored token counts are recalculate
 
 ## Optimization Strategies
 
-### 1. Use gpt-5-mini for Daily Audits
+### 1. Use gpt-5-mini for Frequent Audits
 
-Our [benchmark](../benchmark.md) showed gpt-5-mini ($0.03/run) hits 5/6 cross-model consensus issues with minimal noise — the best daily value of all 10 models tested:
+Our [benchmark](../benchmark.md) showed gpt-5-mini ($0.03/run) hits 5/6 cross-model consensus issues with minimal noise — excellent value for frequent runs:
 
 ```yaml
 repos:

--- a/docs/guides/scheduling.md
+++ b/docs/guides/scheduling.md
@@ -32,9 +32,9 @@ noxaudit run
 noxaudit run --focus all
 ```
 
-## Daily CI with GitHub Actions
+## Scheduled Runs with GitHub Actions
 
-Run a full audit every morning:
+Run a full audit on a schedule (e.g., daily):
 
 ```yaml
 name: Noxaudit Audit

--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -1,6 +1,6 @@
 # GitHub Actions
 
-Noxaudit includes a GitHub Action for automated nightly audits with batch API support.
+Noxaudit includes a GitHub Action for automated audits with batch API support.
 
 ## Basic Workflow
 


### PR DESCRIPTION
Closes #104

## Summary
## Problem

Several docs pages present daily/nightly scheduling as the primary workflow. The tool is on-demand first; scheduling is an optional add-on.

## Changes

- [ ] `docs/getting-started/first-audit.md:133` — rename "Set Up Nightly Runs" → "Set Up Scheduled Runs" or "Automate Your Audits"
- [ ] `docs/integrations/github-actions.md:3` — "automated nightly audits" → "automated audits"
- [ ] `docs/guides/scheduling.md` — reframe "Daily CI with GitHub Actions" as one option, not the default
- 

## Changes
11585b6 docs: reframe scheduling as optional, not the default path

`docs/getting-started/first-audit.md
docs/guides/cost-management.md
docs/guides/scheduling.md
docs/integrations/github-actions.md`

## Acceptance Criteria
- [ ] `docs/getting-started/first-audit.md:133` — rename "Set Up Nightly Runs" → "Set Up Scheduled Runs" or "Automate Your Audits"
- [ ] `docs/integrations/github-actions.md:3` — "automated nightly audits" → "automated audits"
- [ ] `docs/guides/scheduling.md` — reframe "Daily CI with GitHub Actions" as one option, not the default
- [ ] `docs/guides/cost-management.md:3` — "cheap enough to run daily" → "cheap enough to run frequently"
- [ ] `docs/guides/cost-management.md` — "assuming daily runs" → present as per-run cost first, monthly projection as optional context

## Verification
- Tests: passed
- Branch: `feat/docs-reframe-scheduling-as-optional-not-104`

Automated PR by Ralph | Model: claude-haiku-4-5 | Duration: 2m