### PR TITLE
fix: remove "daily" assumptions from pricing.py output

### DIFF
--- a/noxaudit/pricing.py
+++ b/noxaudit/pricing.py
@@ -348,7 +348,7 @@ def build_estimate_report(
             desc = f"{alt_provider} ({alt_key})"
             note = ""
             if alt_provider == "gemini" and savings_pct >= 90:
-                note = " — recommended for daily audits"
+                note = " — best value"
             elif "sonnet" in alt_key:
                 note = " — similar quality, lower cost"
             lines.append(f"    {desc:<38} ~${alt_cost:.2f}   {savings_pct}% cheaper{note}")
@@ -379,10 +379,10 @@ def build_estimate_report(
         )
         lines.append("")
 
-    # Monthly projection (assuming daily runs)
+    # Monthly projection (if run daily)
     monthly_runs = 30
     monthly_cost = cost * monthly_runs
-    lines.append(f"  Monthly estimate: ~${monthly_cost:.2f} (assuming daily runs)")
+    lines.append(f"  Monthly estimate: ~${monthly_cost:.2f} (if run daily)")
 
     if alternatives:
         cheapest_key, cheapest_provider, cheapest_cost, _ = alternatives[0]
@@ -396,11 +396,9 @@ def build_estimate_report(
         cheapest_key, cheapest_provider, cheapest_cost, _ = alternatives[0]
         if cheapest_provider == "gemini":
             lines.append(
-                f"  Recommendation: Use gemini for daily audits (~${cheapest_cost:.2f}/run)."
+                f"  Recommendation: {cheapest_key} offers significantly lower cost (~${cheapest_cost:.2f}/run)."
             )
-            lines.append(
-                "  Reserve anthropic for monthly deep dives where finding depth matters most."
-            )
+            lines.append("  Reserve anthropic for deep dives where finding depth matters most.")
             lines.append("")
 
     return "\n".join(lines)

--- a/tests/test_estimate.py
+++ b/tests/test_estimate.py
@@ -231,7 +231,7 @@ class TestEstimateCLI:
         runner = CliRunner()
         result = runner.invoke(main, ["--config", cfg, "estimate", "--focus", "security"])
         assert result.exit_code == 0, result.output
-        assert "assuming daily runs" in result.output
+        assert "if run daily" in result.output
 
     def test_no_repos_configured(self, tmp_path):
         cfg_path = tmp_path / "noxaudit.yml"

--- a/uv.lock
+++ b/uv.lock
@@ -833,7 +833,7 @@ wheels = [
 
 [[package]]
 name = "noxaudit"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Closes #105

## Summary
## Problem

`noxaudit estimate` output assumes daily runs:
- `pricing.py:351` — "recommended for daily audits"
- `pricing.py:382-385` — "Monthly estimate: ~$X.XX (assuming daily runs)"
- `pricing.py:399` — "Use gemini for daily audits"

This bakes in a cadence assumption that doesn't apply to most open source users.

## Changes

- [ ] Lead with per-run cost (already shown)
- [ ] Make monthly projection optional or reframe: "If run daily: ~$X.XX/month" rather than assuming it
- [ ] Drop "recommen

## Changes
eddaf38 fix: remove "daily" assumptions from pricing.py output

`noxaudit/pricing.py
tests/test_estimate.py
uv.lock`

## Acceptance Criteria
- [ ] Lead with per-run cost (already shown)
- [ ] Make monthly projection optional or reframe: "If run daily: ~$X.XX/month" rather than assuming it
- [ ] Drop "recommended for daily audits" — recommend by quality/cost ratio instead
- [ ] `tests/test_estimate.py:234` — update assertion to match new wording

## Verification
- Tests: passed
- Branch: `feat/fix-remove-daily-assumptions-from-pricin-105`

Automated PR by Ralph | Model: claude-haiku-4-5 | Duration: 3m