### PR TITLE
fix: handle list responses from dedup LLM provider

### DIFF
--- a/noxaudit/dedup.py
+++ b/noxaudit/dedup.py
@@ -289,6 +289,12 @@ def deduplicate_findings(
         print(f"[dedup] LLM call failed ({exc}), returning original findings", file=sys.stderr)
         return findings
 
+    # _call_provider may return a list — take first dict
+    if isinstance(response, list):
+        response = response[0] if response and isinstance(response[0], dict) else {}
+    if not isinstance(response, dict):
+        return findings
+
     mappings = response.get("mappings", [])
     if not mappings:
         return findings


### PR DESCRIPTION
## Summary
- Same list-response bug as validate.py — `_call_provider` can return a list instead of a dict from some providers
- Extract first dict element from list responses, fall back gracefully for non-dict responses
- Discovered during pipeline benchmark testing

## Test plan
- [x] 22 existing dedup tests pass
- [x] Verified against real benchmark data (3 chunked runs through full pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)