### PR TITLE
feat: confidence scoring based on cross-run frequency

### DIFF
--- a/noxaudit/confidence.py
+++ b/noxaudit/confidence.py
@@ -1,0 +1,107 @@
+"""Confidence scoring based on cross-run finding frequency.
+
+Reads findings-history.jsonl and scores each finding by how often it has
+appeared across previous runs. Findings seen consistently are high
+confidence; one-off findings are low confidence.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from noxaudit.models import Finding
+
+HISTORY_FILE = ".noxaudit/findings-history.jsonl"
+
+# Thresholds: what fraction of recent runs must contain a finding
+HIGH_THRESHOLD = 0.6  # Seen in 60%+ of runs
+MEDIUM_THRESHOLD = 0.3  # Seen in 30%+ of runs
+# Below MEDIUM_THRESHOLD = low
+
+
+def _finding_key(finding: Finding) -> str:
+    """Stable key for matching findings across runs.
+
+    Uses file + title (lowercased) since dedup normalizes titles.
+    """
+    return f"{finding.file}::{finding.title.lower()}"
+
+
+def load_history(base_path: str | Path = ".", max_runs: int = 10) -> list[set[str]]:
+    """Load recent finding keys from history.
+
+    Returns a list of sets, one per run, each containing finding keys.
+    Most recent runs first, up to max_runs.
+    """
+    path = Path(base_path) / HISTORY_FILE
+    if not path.exists():
+        return []
+
+    runs: list[set[str]] = []
+    try:
+        for line in path.read_text().splitlines():
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            keys = set()
+            for f in record.get("findings", []):
+                key = f"{f.get('file', '')}::{f.get('title', '').lower()}"
+                keys.add(key)
+            runs.append(keys)
+    except (json.JSONDecodeError, OSError):
+        return []
+
+    # Return most recent runs (last N)
+    return runs[-max_runs:]
+
+
+def score_findings(
+    findings: list[Finding],
+    base_path: str | Path = ".",
+    max_runs: int = 10,
+) -> list[Finding]:
+    """Score findings based on how often they appear in run history.
+
+    Only upgrades confidence — if validation already set a confidence,
+    history can promote it but won't demote it.
+
+    Args:
+        findings: Current run's findings (after validate + dedup).
+        base_path: Repo root where .noxaudit/ lives.
+        max_runs: How many recent runs to consider.
+
+    Returns:
+        The same findings list with confidence fields updated.
+    """
+    history = load_history(base_path, max_runs)
+
+    if not history:
+        # No history yet — first run. Keep existing confidence from validation.
+        return findings
+
+    num_runs = len(history)
+
+    for finding in findings:
+        key = _finding_key(finding)
+
+        # Count how many historical runs contain this finding
+        appearances = sum(1 for run_keys in history if key in run_keys)
+        frequency = appearances / num_runs
+
+        if frequency >= HIGH_THRESHOLD:
+            history_confidence = "high"
+        elif frequency >= MEDIUM_THRESHOLD:
+            history_confidence = "medium"
+        else:
+            history_confidence = "low"
+
+        # Merge: if no existing confidence, use history. Otherwise take the higher.
+        confidence_rank = {"low": 1, "medium": 2, "high": 3}
+        current_rank = confidence_rank.get(finding.confidence, 0)
+        history_rank = confidence_rank.get(history_confidence, 1)
+
+        if finding.confidence is None or history_rank > current_rank:
+            finding.confidence = history_confidence
+
+    return findings

--- a/noxaudit/mcp/state.py
+++ b/noxaudit/mcp/state.py
@@ -108,4 +108,5 @@ def _finding_from_dict(raw: dict) -> Finding:
         description=raw["description"],
         suggestion=raw.get("suggestion"),
         focus=raw.get("focus"),
+        confidence=raw.get("confidence"),
     )

--- a/noxaudit/models.py
+++ b/noxaudit/models.py
@@ -35,6 +35,7 @@ class Finding:
     description: str
     suggestion: str | None = None
     focus: str | None = None
+    confidence: str | None = None  # high, medium, low — from validation or history
 
     def to_dict(self) -> dict[str, Any]:
         d = {
@@ -48,6 +49,8 @@ class Finding:
         }
         if self.focus:
             d["focus"] = self.focus
+        if self.confidence:
+            d["confidence"] = self.confidence
         return d
 
 

--- a/noxaudit/reporter.py
+++ b/noxaudit/reporter.py
@@ -55,6 +55,8 @@ def generate_report(result: AuditResult) -> str:
                 lines.append("")
                 lines.append(f"**Location**: {loc}  ")
                 lines.append(f"**ID**: `{f.id}`")
+                if f.confidence:
+                    lines.append(f"**Confidence**: {f.confidence}")
                 lines.append("")
                 lines.append(f"{f.description}")
                 if f.suggestion:

--- a/noxaudit/runner.py
+++ b/noxaudit/runner.py
@@ -467,6 +467,14 @@ def _retrieve_repo(config, batch_info, focus_label, default_focus, output_format
         if len(findings) < original_count:
             print(f"[{repo_name}] Dedup: {original_count} → {len(findings)} findings")
 
+    # Score findings by cross-run frequency
+    if findings:
+        from noxaudit.confidence import score_findings
+
+        repo_config = next((r for r in config.repos if r.name == repo_name), None)
+        repo_path = repo_config.path if repo_config else "."
+        findings = score_findings(findings, base_path=repo_path)
+
     # Log cost ledger entry
     file_count = batch_info.get("file_count", 0)
     if file_count > 0:
@@ -669,6 +677,12 @@ def _run_repo_sync(config, repo, focus_names, provider_name, dry_run, output_for
         findings = deduplicate_findings(findings, config.dedup)
         if len(findings) < original_count:
             print(f"[{repo.name}] Dedup: {original_count} → {len(findings)} findings")
+
+    # Score findings by cross-run frequency
+    if findings:
+        from noxaudit.confidence import score_findings
+
+        findings = score_findings(findings, base_path=repo.path)
 
     # Log cost ledger entry
     usage = provider.get_last_usage()

--- a/noxaudit/validate.py
+++ b/noxaudit/validate.py
@@ -169,6 +169,7 @@ def validate_findings(
             rank = confidence_rank.get(result.confidence, 2)
 
             if rank >= min_rank:
+                finding.confidence = result.confidence
                 validated.append(finding)
             else:
                 dropped += 1

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,0 +1,182 @@
+"""Tests for confidence scoring module."""
+
+from __future__ import annotations
+
+import json
+
+from noxaudit.confidence import (
+    _finding_key,
+    load_history,
+    score_findings,
+)
+from noxaudit.models import Finding, Severity
+
+
+def _f(title: str = "Test finding", file: str = "app.py", confidence: str | None = None):
+    return Finding(
+        id="test-id",
+        severity=Severity.MEDIUM,
+        file=file,
+        line=1,
+        title=title,
+        description="desc",
+        confidence=confidence,
+    )
+
+
+class TestFindingKey:
+    def test_basic(self):
+        f = _f(title="Missing Auth", file="auth.py")
+        assert _finding_key(f) == "auth.py::missing auth"
+
+    def test_case_insensitive(self):
+        f1 = _f(title="Missing Auth")
+        f2 = _f(title="missing auth")
+        assert _finding_key(f1) == _finding_key(f2)
+
+
+class TestLoadHistory:
+    def test_no_file(self, tmp_path):
+        result = load_history(tmp_path)
+        assert result == []
+
+    def test_single_run(self, tmp_path):
+        history_path = tmp_path / ".noxaudit" / "findings-history.jsonl"
+        history_path.parent.mkdir(parents=True)
+        record = {
+            "timestamp": "2026-03-13",
+            "repo": "test",
+            "focus": "all",
+            "findings": [
+                {"file": "app.py", "title": "Bug A"},
+                {"file": "app.py", "title": "Bug B"},
+            ],
+        }
+        history_path.write_text(json.dumps(record) + "\n")
+
+        result = load_history(tmp_path)
+        assert len(result) == 1
+        assert "app.py::bug a" in result[0]
+        assert "app.py::bug b" in result[0]
+
+    def test_max_runs(self, tmp_path):
+        history_path = tmp_path / ".noxaudit" / "findings-history.jsonl"
+        history_path.parent.mkdir(parents=True)
+        lines = []
+        for i in range(20):
+            record = {
+                "findings": [{"file": "app.py", "title": f"Bug {i}"}],
+            }
+            lines.append(json.dumps(record))
+        history_path.write_text("\n".join(lines) + "\n")
+
+        result = load_history(tmp_path, max_runs=5)
+        assert len(result) == 5
+        # Should be the last 5
+        assert "app.py::bug 15" in result[0]
+
+
+class TestScoreFindings:
+    def test_no_history_keeps_existing(self, tmp_path):
+        findings = [_f(confidence="medium")]
+        result = score_findings(findings, base_path=tmp_path)
+        assert result[0].confidence == "medium"
+
+    def test_no_history_no_confidence(self, tmp_path):
+        findings = [_f()]
+        result = score_findings(findings, base_path=tmp_path)
+        assert result[0].confidence is None  # No history, no change
+
+    def test_high_frequency_scores_high(self, tmp_path):
+        history_path = tmp_path / ".noxaudit" / "findings-history.jsonl"
+        history_path.parent.mkdir(parents=True)
+        # Finding appears in 8 of 10 runs (80% > HIGH_THRESHOLD)
+        lines = []
+        for i in range(10):
+            findings_data = []
+            if i < 8:  # Present in first 8 runs
+                findings_data.append({"file": "app.py", "title": "Bug A"})
+            lines.append(json.dumps({"findings": findings_data}))
+        history_path.write_text("\n".join(lines) + "\n")
+
+        findings = [_f(title="Bug A", file="app.py")]
+        result = score_findings(findings, base_path=tmp_path)
+        assert result[0].confidence == "high"
+
+    def test_medium_frequency_scores_medium(self, tmp_path):
+        history_path = tmp_path / ".noxaudit" / "findings-history.jsonl"
+        history_path.parent.mkdir(parents=True)
+        # Finding appears in 4 of 10 runs (40% — between thresholds)
+        lines = []
+        for i in range(10):
+            findings_data = []
+            if i < 4:
+                findings_data.append({"file": "app.py", "title": "Bug A"})
+            lines.append(json.dumps({"findings": findings_data}))
+        history_path.write_text("\n".join(lines) + "\n")
+
+        findings = [_f(title="Bug A", file="app.py")]
+        result = score_findings(findings, base_path=tmp_path)
+        assert result[0].confidence == "medium"
+
+    def test_low_frequency_scores_low(self, tmp_path):
+        history_path = tmp_path / ".noxaudit" / "findings-history.jsonl"
+        history_path.parent.mkdir(parents=True)
+        # Finding appears in 1 of 10 runs (10% < MEDIUM_THRESHOLD)
+        lines = []
+        for i in range(10):
+            findings_data = []
+            if i == 0:
+                findings_data.append({"file": "app.py", "title": "Bug A"})
+            lines.append(json.dumps({"findings": findings_data}))
+        history_path.write_text("\n".join(lines) + "\n")
+
+        findings = [_f(title="Bug A", file="app.py")]
+        result = score_findings(findings, base_path=tmp_path)
+        assert result[0].confidence == "low"
+
+    def test_never_seen_stays_low(self, tmp_path):
+        history_path = tmp_path / ".noxaudit" / "findings-history.jsonl"
+        history_path.parent.mkdir(parents=True)
+        lines = []
+        for _ in range(5):
+            lines.append(json.dumps({"findings": [{"file": "other.py", "title": "Other"}]}))
+        history_path.write_text("\n".join(lines) + "\n")
+
+        findings = [_f(title="New Bug", file="app.py", confidence="low")]
+        result = score_findings(findings, base_path=tmp_path)
+        assert result[0].confidence == "low"
+
+    def test_history_upgrades_but_never_downgrades(self, tmp_path):
+        """If validation said high, history saying low shouldn't downgrade."""
+        history_path = tmp_path / ".noxaudit" / "findings-history.jsonl"
+        history_path.parent.mkdir(parents=True)
+        # Finding appears in 1 of 10 runs — history would say "low"
+        lines = []
+        for i in range(10):
+            findings_data = []
+            if i == 0:
+                findings_data.append({"file": "app.py", "title": "Bug A"})
+            lines.append(json.dumps({"findings": findings_data}))
+        history_path.write_text("\n".join(lines) + "\n")
+
+        findings = [_f(title="Bug A", file="app.py", confidence="high")]
+        result = score_findings(findings, base_path=tmp_path)
+        assert result[0].confidence == "high"  # Not downgraded
+
+    def test_history_upgrades_from_validation(self, tmp_path):
+        """History can upgrade a medium validation to high."""
+        history_path = tmp_path / ".noxaudit" / "findings-history.jsonl"
+        history_path.parent.mkdir(parents=True)
+        # Finding in 8/10 runs
+        lines = []
+        for i in range(10):
+            findings_data = []
+            if i < 8:
+                findings_data.append({"file": "app.py", "title": "Bug A"})
+            lines.append(json.dumps({"findings": findings_data}))
+        history_path.write_text("\n".join(lines) + "\n")
+
+        findings = [_f(title="Bug A", file="app.py", confidence="medium")]
+        result = score_findings(findings, base_path=tmp_path)
+        assert result[0].confidence == "high"  # Upgraded by history


### PR DESCRIPTION
## Summary
- Add `confidence` field to Finding model (high/medium/low)
- Validate stage now preserves confidence on findings instead of discarding it
- New `confidence.py` module scores findings by how often they appear across recent runs
  - Reads `findings-history.jsonl` (already populated by existing runs)
  - 60%+ frequency = high, 30%+ = medium, below = low
  - History can upgrade but never downgrade validation confidence
- Confidence shown in reports and serialized in state files

Closes #121

## How it works
Pipeline is now: **Audit → Validate → Dedup → Confidence → Report**

First run: confidence comes only from validation (or None if validate is off).
Subsequent runs: cross-run frequency boosts confidence for recurring findings.

## Test plan
- [x] 13 new tests covering finding keys, history loading, scoring thresholds, upgrade/downgrade behavior
- [x] Full suite: 437 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)