### PR TITLE
fix: increase max_completion_tokens from 4096 to 16384

### DIFF
--- a/noxaudit/providers/openai.py
+++ b/noxaudit/providers/openai.py
@@ -74,7 +74,7 @@ class OpenAIProvider(BaseProvider):
     ) -> str:
         """Submit a batch request via OpenAI Batch API. Returns the batch ID."""
         user_message = self._build_user_message(files, decision_context)
-        max_tokens = 4096 * num_focus_areas
+        max_tokens = 16384 * num_focus_areas
 
         request = {
             "custom_id": custom_id,
@@ -210,7 +210,7 @@ class OpenAIProvider(BaseProvider):
     ) -> list[Finding]:
         """Direct chat completion — no batch queue."""
         user_message = self._build_user_message(files, decision_context)
-        max_tokens = 4096 * num_focus_areas
+        max_tokens = 16384 * num_focus_areas
 
         response = self.client.chat.completions.create(
             model=self.model,

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -241,7 +241,7 @@ class TestSubmitBatch:
             )
 
         entry = json.loads(jsonl_text.strip())
-        assert entry["body"]["max_completion_tokens"] == 4096 * 3
+        assert entry["body"]["max_completion_tokens"] == 16384 * 3
 
 
 class TestRetrieveBatch:


### PR DESCRIPTION
## Root cause
gpt-5-mini uses reasoning tokens. With max_completion_tokens=4096, all 4096 went to reasoning_tokens, leaving content empty. Every batch returned finish_reason=length with 0 findings.

## Fix
Bumped to 16384. Affects both submit_batch and run_sync.

## Test plan
- [x] 439 tests pass