### PR TITLE
fix: route pre-pass to gpt-5-mini to avoid long-context SKU

### DIFF
--- a/noxaudit/prepass.py
+++ b/noxaudit/prepass.py
@@ -2,8 +2,33 @@
 
 from __future__ import annotations
 
+import os
+
 from noxaudit.models import ContentTier, FileClassification, FileContent, PrepassResult
 from noxaudit.pricing import MODEL_PRICING
+
+# Pre-pass always runs on gpt-5-mini when available: classification doesn't need
+# a premium model, and using the main audit's model (e.g. gpt-5.4) synchronously
+# paid ~$17/Sunday at the "long context" SKU because chunks blew past the 272K
+# tier threshold. gpt-5-mini has no tier and is ~20x cheaper per token.
+PREPASS_MODEL = "gpt-5-mini"
+
+
+def _build_prepass_provider(fallback_provider):
+    """Build a dedicated pre-pass provider (gpt-5-mini).
+
+    Falls back to the main audit provider when OpenAI is unavailable — typically
+    when OPENAI_API_KEY is not set (Anthropic-only or Gemini-only users).
+    """
+    if not os.environ.get("OPENAI_API_KEY"):
+        return fallback_provider
+    try:
+        from noxaudit.providers.openai import OpenAIProvider
+
+        return OpenAIProvider(model=PREPASS_MODEL)
+    except (ImportError, ValueError):
+        return fallback_provider
+
 
 # Classification prompt: asks the provider to classify files into content tiers.
 # We reuse the existing run_audit() interface — severity encodes the tier:
@@ -121,21 +146,28 @@ def run_prepass(
     if not files:
         return PrepassResult(classified=[], original_count=0, retained_count=0), []
 
-    print(f"  Pre-pass: classifying {len(files)} files...")
+    prepass_provider = _build_prepass_provider(provider)
+    print(
+        f"  Pre-pass: classifying {len(files)} files "
+        f"via {prepass_provider.name} ({prepass_provider.model})..."
+    )
     prompt = build_classification_prompt(focus_names)
 
-    # Chunk files to fit within the model's context window for sync API calls
-    pricing = MODEL_PRICING.get(getattr(provider, "model", ""))
-    max_tokens = (
-        pricing.context_window if pricing else 200_000
-    ) // 2  # 50% headroom for prompt/formatting overhead
+    # Chunk files to fit within the pre-pass model's context window for sync
+    # API calls. We cap at half the context window for prompt/formatting
+    # headroom, and additionally cap at the tier_threshold (when present) so
+    # sync calls don't fall into the long-context SKU.
+    pricing = MODEL_PRICING.get(getattr(prepass_provider, "model", ""))
+    base_cap = (pricing.context_window if pricing else 200_000) // 2
+    tier_cap = pricing.tier_threshold if pricing and pricing.tier_threshold else base_cap
+    max_tokens = min(base_cap, tier_cap)
     chunks = _chunk_by_tokens(files, max_tokens)
 
     classification_findings = []
     for i, chunk in enumerate(chunks):
         if len(chunks) > 1:
             print(f"  Pre-pass chunk {i + 1}/{len(chunks)} ({len(chunk)} files)...")
-        classification_findings.extend(provider.run_sync(chunk, prompt, ""))
+        classification_findings.extend(prepass_provider.run_sync(chunk, prompt, ""))
 
     # Build a tier map from the classification findings
     tier_map: dict[str, ContentTier] = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,14 @@ import pytest
 from noxaudit.models import AuditResult, Finding, Severity
 
 
+@pytest.fixture(autouse=True)
+def _clear_openai_key_for_prepass(monkeypatch):
+    """Pre-pass builds a dedicated gpt-5-mini provider when OPENAI_API_KEY is
+    set. Clear it by default in tests so the provider fallback kicks in and
+    mocked providers receive the pre-pass run_sync call as tests expect."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
 @pytest.fixture
 def tmp_repo(tmp_path):
     """Create a minimal repo structure for file-gathering tests."""


### PR DESCRIPTION
## Summary

- Pre-pass sync calls with gpt-5.4 were hitting OpenAI's \"long context\" SKU (\$5/M input, no batch discount) because chunks were sized to `context_window/2` = 525K, well over the 272K tier threshold.
- This billed ~\$17.31 on 2026-04-19 (consistent pattern every Sunday: \$14.17 Apr 5, \$15.08 Apr 12, \$17.31 Apr 19) — ~8x the cost of the actual audits.
- Pre-pass now builds a dedicated `OpenAIProvider(gpt-5-mini)` for classification when `OPENAI_API_KEY` is set. Falls back to the main audit provider otherwise. Chunks are also capped at `min(context_window/2, tier_threshold)` so the fallback path stays in standard tier too.
- Expected: \$17.31/Sunday long-context input → ~\$0; total Sunday pre-pass + audit cost drops from ~\$21 to ~\$3.

## Test plan

- [x] `pytest` — 439 pass
- [x] Existing prepass tests (runner + cli_integration, 11 tests) still pass; added autouse conftest fixture clears `OPENAI_API_KEY` so mocked providers still receive the pre-pass `run_sync` call regardless of the runner's env.
- [ ] Verify next Sunday's OpenAI usage breakdown shows no `gpt-5.4-2026-03-05, input, long context` line item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)