### PR TITLE
chore: remove npm dependabot entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    groups:
-      minor-patch:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
The `npm_and_yarn` dependabot job has been failing every week since at least March 31 because there's no `package.json` in this repo. This was copy-pasted from another repo config and never applied here.

Removes the npm block; keeps the `github-actions` entry which works correctly.