### PR TITLE
chore: add arqo issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,19 @@
+---
+name: Bug
+about: Something is broken
+labels: bug
+---
+
+## Symptom
+<!-- What's happening? Include error messages, screenshots, or steps to reproduce. -->
+
+## Expected
+<!-- What should happen instead? -->
+
+## Acceptance Criteria
+<!-- Testable conditions for the fix. -->
+- [ ] Bug no longer reproduces given the steps above
+- [ ]
+
+## Notes
+<!-- Optional: technical context, related issues. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,19 @@
+---
+name: Feature
+about: New capability or enhancement
+labels: enhancement
+---
+
+## Problem
+<!-- What is missing today? What user-visible behavior is broken or absent? Be concrete. -->
+
+## Goal
+<!-- What state do we want to reach? One sentence on the outcome. -->
+
+## Acceptance Criteria
+<!-- Bulleted, testable conditions. Each one should be verifiable by a person looking at the shipped code. -->
+- [ ]
+- [ ]
+
+## Notes
+<!-- Optional: technical context, constraints, related issues. -->


### PR DESCRIPTION
Adds standard issue templates (feature.md + bug.md) so arqo's auto-spec can detect structured Acceptance Criteria and skip LLM refinement on pre-structured issues.