### PR TITLE
fix: remove dead webhook field from NotificationConfig

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -26,7 +26,6 @@ All configuration lives in `noxaudit.yml` in your project root.
 | `notifications` | list | `[]` | Notification channel configurations |
 | `notifications[].channel` | string | `telegram` | Notification channel type |
 | `notifications[].target` | string | `""` | Channel-specific target (e.g., Telegram chat ID) |
-| `notifications[].webhook` | string | `""` | Webhook URL (for webhook-based channels) |
 | `issues` | mapping | — | GitHub issue creation settings |
 | `issues.enabled` | bool | `false` | Enable auto-creation of GitHub issues |
 | `issues.severity_threshold` | string | `medium` | Minimum severity for issue creation: `low`, `medium`, or `high` |

--- a/noxaudit/config.py
+++ b/noxaudit/config.py
@@ -28,7 +28,6 @@ class BudgetConfig:
 class NotificationConfig:
     channel: str = "telegram"
     target: str = ""
-    webhook: str = ""
 
 
 @dataclass
@@ -197,7 +196,6 @@ def load_config(config_path: str | Path | None = None) -> NoxauditConfig:
             NotificationConfig(
                 channel=n.get("channel", "telegram"),
                 target=n.get("target", ""),
-                webhook=n.get("webhook", ""),
             )
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,6 +73,31 @@ class TestLoadConfig:
         assert "vendor" in config.repos[0].exclude_patterns
 
 
+class TestNotificationConfig:
+    def test_webhook_key_ignored_on_load(self, tmp_config):
+        path = tmp_config("""\
+            notifications:
+              - channel: telegram
+                target: "12345"
+                webhook: "https://example.com/hook"
+        """)
+        config = load_config(path)
+        assert len(config.notifications) == 1
+        assert config.notifications[0].channel == "telegram"
+        assert config.notifications[0].target == "12345"
+        assert not hasattr(config.notifications[0], "webhook")
+
+    def test_notification_without_webhook_loads(self, tmp_config):
+        path = tmp_config("""\
+            notifications:
+              - channel: telegram
+                target: "12345"
+        """)
+        config = load_config(path)
+        assert len(config.notifications) == 1
+        assert config.notifications[0].target == "12345"
+
+
 class TestDeprecationWarnings:
     def test_schedule_key_emits_warning(self, tmp_config):
         path = tmp_config("""\


### PR DESCRIPTION
Removes the `webhook` stub field from `NotificationConfig` — no webhook dispatcher exists, so the field had no effect. Config files that still contain a stray `webhook:` key under a `notifications[]` entry load without error (the key is simply ignored).

## Changes
- Removed `webhook: str = ""` from the `NotificationConfig` dataclass
- Removed `webhook=n.get("webhook", "")` from the `load_config` notifications loop
- Removed the `notifications[].webhook` row from `docs/reference/configuration.md`
- Added tests for stray `webhook:` key being silently ignored and for clean notification loading

Closes #158