### PR TITLE
fix(benchmark): drop invalid focus token and phantom model IDs in corpus.yml

### DIFF
--- a/benchmark/corpus.yml
+++ b/benchmark/corpus.yml
@@ -12,11 +12,9 @@ matrix:
   providers:
     - name: gemini
       models:
-        - gemini-2.5-flash-lite
         - gemini-2.5-flash
-        - gemini-3-flash
+        - gemini-3-flash-preview
         - gemini-2.5-pro
-        - gemini-3.1-pro-preview
 
     - name: anthropic
       models:
@@ -27,13 +25,12 @@ matrix:
       models:
         - gpt-5-nano
         - gpt-5-mini
-        - gpt-5.2
+        - gpt-5.4
 
   # --- Focus tiers ---
-  # "security" for targeted security-only runs; "does_it_work" for basic functionality; "all" for full 7-area audits
+  # "security" for targeted security-only runs; "all" for full 7-area audits
   focus:
     - security
-    - does_it_work
     - all
 
   # --- Number of runs per combination (for variance measurement) ---

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 # ---------------------------------------------------------------------------
@@ -267,3 +268,56 @@ class TestRunOneSkipLogic:
         assert record["meta"]["error"] is not None
         assert "findings_count" in record
         assert "tokens" in record
+
+
+# ---------------------------------------------------------------------------
+# corpus.yml validation
+# ---------------------------------------------------------------------------
+
+_CORPUS_PATH = Path(__file__).parent.parent / "benchmark" / "corpus.yml"
+
+
+def _load_corpus_matrix():
+    with _CORPUS_PATH.open() as f:
+        return yaml.safe_load(f)["matrix"]
+
+
+class TestCorpusYmlFocusTokens:
+    """Every focus token in benchmark/corpus.yml must be a valid FOCUS_AREAS key or 'all'."""
+
+    def test_all_focus_tokens_valid(self):
+        from noxaudit.focus import FOCUS_AREAS
+
+        matrix = _load_corpus_matrix()
+        valid = set(FOCUS_AREAS.keys()) | {"all", "security"}
+        for token in matrix.get("focus", []):
+            assert token in valid, (
+                f"corpus.yml focus token {token!r} is not a valid focus area. "
+                f"Valid: {sorted(valid)}"
+            )
+
+    def test_focus_tokens_resolve_without_error(self):
+        from noxaudit.config import NoxauditConfig
+        from noxaudit.runner import _resolve_focus_names
+
+        matrix = _load_corpus_matrix()
+        config = NoxauditConfig()
+        for token in matrix.get("focus", []):
+            # Should not raise ValueError
+            resolved = _resolve_focus_names(token, config)
+            assert len(resolved) > 0, f"focus token {token!r} resolved to empty list"
+
+
+class TestCorpusYmlModelIds:
+    """Every model ID in benchmark/corpus.yml must be a key in MODEL_PRICING."""
+
+    def test_all_model_ids_in_pricing(self):
+        from noxaudit.pricing import MODEL_PRICING
+
+        matrix = _load_corpus_matrix()
+        for provider in matrix.get("providers", []):
+            for model in provider.get("models", []):
+                assert model in MODEL_PRICING, (
+                    f"corpus.yml model {model!r} (provider: {provider['name']!r}) "
+                    f"has no entry in MODEL_PRICING"
+                )


### PR DESCRIPTION
## Summary

- Removes `does_it_work` from `matrix.focus` — it is not a key in `FOCUS_AREAS` and causes `ValueError: Unknown focus area` at runtime
- Updates the comment above `focus:` to stop describing `does_it_work`
- Removes `gemini-2.5-flash-lite` and `gemini-3.1-pro-preview` — neither has a `MODEL_PRICING` entry
- Corrects `gemini-3-flash` → `gemini-3-flash-preview` (actual pricing key)
- Corrects `gpt-5.2` → `gpt-5.4` (actual pricing key)
- Adds `TestCorpusYmlFocusTokens` and `TestCorpusYmlModelIds` in `tests/test_benchmark.py` to guard against regressions

## Test plan

- [ ] `pytest tests/test_benchmark.py` — all 24 tests pass, including the 3 new corpus validation tests
- [ ] Full `pytest` — 444/444 pass

Closes #159